### PR TITLE
:rocket: Force HTTP2 in API calls

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -185,7 +185,10 @@ func newHTTPClient(insecure, debug bool) *http.Client {
 	tlsCfg := &tls.Config{
 		InsecureSkipVerify: insecure, // #nosec G402 — intentional, controlled by --insecure flag
 	}
-	var transport http.RoundTripper = &http.Transport{TLSClientConfig: tlsCfg}
+	var transport http.RoundTripper = &http.Transport{
+		TLSClientConfig:   tlsCfg,
+		ForceAttemptHTTP2: true,
+	}
 	if debug {
 		transport = &debugTransport{wrapped: transport}
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -58,6 +58,7 @@ func New(baseURL, userAgent string, tokSource oauth2.TokenSource, insecure, debu
 			Source: tokSource,
 			Base: &http.Transport{
 				TLSClientConfig:     tlsCfg,
+				ForceAttemptHTTP2:   true,
 				TLSHandshakeTimeout: 15 * time.Second,
 				// ResponseHeaderTimeout guards against a server that accepts the
 				// connection but never sends headers back. It does NOT limit how


### PR DESCRIPTION
When TLSClientConfig is provided, HTTP2 is not enabled by default.