### PR TITLE
Upgrade go

### DIFF
--- a/.github/workflows/_ci.yml
+++ b/.github/workflows/_ci.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
 
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod
+
       - name: Build (dev)
         run: CGO_ENABLED=0 go build ./...
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.25.9 AS builder
 
 ARG VERSION=dev
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/retyc/retyc-cli
 
-go 1.24.0
+go 1.25.0
+
+toolchain go1.25.9
 
 require (
 	filippo.io/age v1.3.1 // indirect


### PR DESCRIPTION
- Bump go.mod to Go 1.25.0 and pin the toolchain to Go 1.25.9.
- Update the Docker build image to Go 1.25.9.
- Add govulncheck to the CI workflow.