### PR TITLE
:bug: Fix MCP tools returning wrong error when not authenticated

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -54,6 +54,22 @@ func spinnerReader(s *ui.Spinner) func() (string, error) {
 // mustGetToken retrieves a refreshing OAuth2 token source, returning a
 // user-friendly error if authentication is missing or expired.
 func mustGetToken(ctx context.Context, cfg *config.Config) (oauth2.TokenSource, error) {
+	persist := os.Getenv("RETYC_TOKEN") == ""
+
+	// When using stored tokens, check the token file before making any HTTP
+	// calls. This avoids two unnecessary round-trips (FetchOIDCConfig) just to
+	// discover that no token exists — which would otherwise block callers
+	// (e.g. MCP tools) for up to the HTTP timeout duration.
+	if persist {
+		if _, err := config.LoadToken(); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("not authenticated, run `retyc auth login`: %w", auth.ErrNoToken)
+			}
+
+			return nil, fmt.Errorf("loading stored token: %w", err)
+		}
+	}
+
 	httpClient := newHTTPClient(insecure, debug)
 
 	oidcCfg, err := api.FetchOIDCConfig(ctx, cfg.API.BaseURL, httpClient)
@@ -65,13 +81,11 @@ func mustGetToken(ctx context.Context, cfg *config.Config) (oauth2.TokenSource, 
 	if err != nil {
 		switch {
 		case errors.Is(err, auth.ErrNoToken), errors.Is(err, auth.ErrNoRefreshToken):
-			return nil, fmt.Errorf("not authenticated, run `retyc auth login`")
+			return nil, fmt.Errorf("not authenticated, run `retyc auth login`: %w", err)
 		default:
 			return nil, fmt.Errorf("authentication failed: %w", err)
 		}
 	}
-
-	persist := os.Getenv("RETYC_TOKEN") == ""
 
 	return auth.NewRefreshingTokenSource(tok, *oidcCfg, httpClient, persist), nil
 }

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -241,6 +241,11 @@ func Refresh(
 	}
 
 	if tr.Error != "" {
+		if tr.Error == "invalid_grant" {
+			// Refresh token is expired or revoked — caller must re-authenticate.
+			return nil, fmt.Errorf("refresh token invalid or expired (%s): %w", tr.ErrorDesc, ErrNoRefreshToken)
+		}
+
 		return nil, fmt.Errorf("refresh error %s: %s", tr.Error, tr.ErrorDesc)
 	}
 

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -284,7 +284,7 @@ func TestRefresh_PreservesRefreshToken(t *testing.T) {
 	}
 }
 
-func TestRefresh_ErrorResponse(t *testing.T) {
+func TestRefresh_InvalidGrant(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(map[string]string{
@@ -298,7 +298,35 @@ func TestRefresh_ErrorResponse(t *testing.T) {
 
 	_, err := Refresh(context.Background(), cfg, "bad-token", http.DefaultClient)
 	if err == nil {
-		t.Error("Refresh() should return error for invalid_grant")
+		t.Fatal("Refresh() should return error for invalid_grant")
+	}
+
+	if !errors.Is(err, ErrNoRefreshToken) {
+		t.Errorf("Refresh() error = %v, want errors.Is(err, ErrNoRefreshToken) to be true", err)
+	}
+}
+
+func TestGetValidToken_EnvToken_InvalidGrant(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "Invalid refresh token",
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("RETYC_TOKEN", "expired-offline-token")
+
+	cfg := config.OIDCConfig{ClientID: "test", TokenURL: srv.URL}
+
+	_, err := GetValidToken(context.Background(), cfg, http.DefaultClient)
+	if err == nil {
+		t.Fatal("GetValidToken() should return error when RETYC_TOKEN refresh returns invalid_grant")
+	}
+
+	if !errors.Is(err, ErrNoRefreshToken) {
+		t.Errorf("GetValidToken() error = %v, want errors.Is(err, ErrNoRefreshToken) to be true", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,7 +111,7 @@ func LoadToken() (*oauth2.Token, error) {
 	f, err := os.Open(path) //nolint:gosec // G304: path is computed internally from configDir
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("no stored token found")
+			return nil, fmt.Errorf("no stored token found: %w", os.ErrNotExist)
 		}
 
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -109,8 +110,8 @@ func TestLoadToken_NoFile(t *testing.T) {
 		t.Fatal("LoadToken() should return error when no token file exists")
 	}
 
-	if err.Error() != "no stored token found" {
-		t.Errorf("error = %q, want 'no stored token found'", err.Error())
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("LoadToken() error = %v, want errors.Is(err, os.ErrNotExist) to be true", err)
 	}
 }
 


### PR DESCRIPTION
- Skip FetchOIDCConfig HTTP calls when no token is stored on disk, preventing MCP tools from hanging up to 30s before returning an error
- Map invalid_grant refresh errors to ErrNoRefreshToken so toolErr correctly emits error_code "not_authenticated" instead of "error"
- Preserve LoadToken error detail in the unauthenticated fast-path message
- Add tests for Refresh invalid_grant sentinel and GetValidToken CI/CD path