### PR TITLE
:bug: Fix GET /dataroom/node/{id} returns a flat node (not the wrappe…

### DIFF
--- a/internal/api/dataroom.go
+++ b/internal/api/dataroom.go
@@ -18,8 +18,7 @@ type Dataroom struct {
 	// NodeNameSaltEnc is an armored AGE ciphertext (session key) containing
 	// the per-dataroom salt used as prefix for node name hashing. Nil when not set.
 	NodeNameSaltEnc *string   `json:"node_name_salt_enc"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	CreatedAt       time.Time `json:"created_at"`
 }
 
 // DataroomPage is a paginated list of datarooms.
@@ -211,9 +210,11 @@ func (c *Client) ListDataroomNodes(
 	return &result, nil
 }
 
-// GetDataroomNode fetches a single node and its current version by node ID.
-func (c *Client) GetDataroomNode(ctx context.Context, nodeID string) (*DataroomNodeItem, error) {
-	var result DataroomNodeItem
+// GetDataroomNode fetches a single node's metadata by node ID.
+// The API returns a flat node (DataroomNodeModel) without any version information;
+// use ListDataroomNodes to obtain a node together with its current version.
+func (c *Client) GetDataroomNode(ctx context.Context, nodeID string) (*DataroomNode, error) {
+	var result DataroomNode
 	if err := c.Get(ctx, "/dataroom/node/"+nodeID, &result); err != nil {
 		return nil, err
 	}

--- a/internal/api/dataroom_test.go
+++ b/internal/api/dataroom_test.go
@@ -485,61 +485,56 @@ func TestGetDataroomUsers(t *testing.T) {
 }
 
 func TestGetDataroomNode(t *testing.T) {
-	typeEnc := "enc-mime"
-	parentID := "parent-1"
+	// The API returns a flat DataroomNodeModel (no "node" wrapper, no version),
+	// matching the real GET /dataroom/node/{id} response. See OpenAPI getDataroomNodeById.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/dataroom/node/node-abc" {
 			t.Errorf("path = %q, want /dataroom/node/node-abc", r.URL.Path)
 		}
-		_ = json.NewEncoder(w).Encode(DataroomNodeItem{
-			Node: DataroomNode{
-				ID:       "node-abc",
-				NameEnc:  "enc-name",
-				TypeEnc:  &typeEnc,
-				ParentID: &parentID,
-			},
-			Version: &DataroomNodeVersion{
-				ID:           "ver-1",
-				NodeID:       "node-abc",
-				OriginalSize: 2048,
-				ChunkCount:   1,
-			},
-		})
+		_, _ = w.Write([]byte(`{
+			"id": "node-abc",
+			"dataroom_id": "dr-1",
+			"parent_id": "parent-1",
+			"name_hash": "hash",
+			"name_enc": "enc-name",
+			"type_enc": "enc-mime"
+		}`))
 	}))
 	defer srv.Close()
 
-	item, err := newTestClient(srv).GetDataroomNode(context.Background(), "node-abc")
+	node, err := newTestClient(srv).GetDataroomNode(context.Background(), "node-abc")
 	if err != nil {
 		t.Fatalf("GetDataroomNode() error = %v", err)
 	}
-	if item.Node.ID != "node-abc" {
-		t.Errorf("Node.ID = %q, want node-abc", item.Node.ID)
+	if node.ID != "node-abc" {
+		t.Errorf("ID = %q, want node-abc", node.ID)
 	}
-	if item.Version == nil {
-		t.Fatal("Version is nil, want non-nil for file node")
+	if node.TypeEnc == nil {
+		t.Fatal("TypeEnc is nil, want non-nil for file node")
 	}
-	if item.Version.OriginalSize != 2048 {
-		t.Errorf("Version.OriginalSize = %d, want 2048", item.Version.OriginalSize)
+	if *node.TypeEnc != "enc-mime" {
+		t.Errorf("TypeEnc = %q, want enc-mime", *node.TypeEnc)
 	}
 }
 
 func TestGetDataroomNode_Directory(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(DataroomNodeItem{
-			Node:    DataroomNode{ID: "dir-1", NameEnc: "enc-name"},
-			Version: nil,
-		})
+		_, _ = w.Write([]byte(`{
+			"id": "dir-1",
+			"dataroom_id": "dr-1",
+			"parent_id": null,
+			"name_hash": "hash",
+			"name_enc": "enc-name",
+			"type_enc": null
+		}`))
 	}))
 	defer srv.Close()
 
-	item, err := newTestClient(srv).GetDataroomNode(context.Background(), "dir-1")
+	node, err := newTestClient(srv).GetDataroomNode(context.Background(), "dir-1")
 	if err != nil {
 		t.Fatalf("GetDataroomNode() error = %v", err)
 	}
-	if item.Node.TypeEnc != nil {
+	if node.TypeEnc != nil {
 		t.Errorf("TypeEnc should be nil for directory node")
-	}
-	if item.Version != nil {
-		t.Errorf("Version should be nil for directory node")
 	}
 }

--- a/internal/service/dataroom.go
+++ b/internal/service/dataroom.go
@@ -241,6 +241,40 @@ func resolvePath(
 	return currentParentID, nil
 }
 
+// resolvePathItem resolves a unix-style path to the full node item (including its
+// current version) of the final component. It locates the parent via resolvePath,
+// then lists the parent so the returned item carries node_version — which the
+// single-node endpoint (GET /dataroom/node/{id}) does not return.
+// Returns nil for an empty path or "/", indicating the dataroom root.
+func resolvePathItem(
+	ctx context.Context, client *api.Client, dataroomID, nodePath string, identity *age.HybridIdentity,
+) (*api.DataroomNodeItem, error) {
+	nodePath = strings.TrimSpace(nodePath)
+	if strings.Trim(nodePath, "/") == "" {
+		return nil, nil
+	}
+
+	parentPath, name := splitPathParent(nodePath)
+	parentID, err := resolvePath(ctx, client, dataroomID, parentPath, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := fetchNodesWithNames(ctx, client, dataroomID, parentID, identity)
+	if err != nil {
+		return nil, err
+	}
+	for _, nn := range nodes {
+		if nn.name == name {
+			item := nn.item
+
+			return &item, nil
+		}
+	}
+
+	return nil, fmt.Errorf("path not found: %s", nodePath)
+}
+
 // resolveGlob resolves a path that may contain glob patterns in any component.
 func resolveGlob(
 	ctx context.Context, client *api.Client, dataroomID, rawPath string, identity *age.HybridIdentity,
@@ -380,7 +414,7 @@ func uploadDataroomFile(
 		if fetchErr != nil {
 			return fmt.Errorf("verifying existing node %q: %w", name, fetchErr)
 		}
-		if existing.Node.TypeEnc == nil {
+		if existing.TypeEnc == nil {
 			return fmt.Errorf("cannot upload file %q: a folder with that name already exists", name)
 		}
 		fmt.Fprintf(os.Stderr, "  %s: adding new version\n", displayName)
@@ -457,7 +491,7 @@ func uploadDataroomDir(
 					if fetchErr != nil {
 						return fmt.Errorf("verifying existing node %s: %w", e.Name(), fetchErr)
 					}
-					if existing.Node.TypeEnc != nil {
+					if existing.TypeEnc != nil {
 						return fmt.Errorf("cannot create folder %q: a file with that name already exists", e.Name())
 					}
 					folderID = existingID
@@ -750,17 +784,12 @@ func DownloadFromDataroom(
 		return downloaded, nil
 	}
 
-	nodeID, err := resolvePath(ctx, client, src.DataroomID, src.Path, sess.Identity)
+	item, err := resolvePathItem(ctx, client, src.DataroomID, src.Path, sess.Identity)
 	if err != nil {
 		return nil, err
 	}
-	if nodeID == nil {
+	if item == nil {
 		return nil, fmt.Errorf("cannot download the root folder")
-	}
-
-	item, err := client.GetDataroomNode(ctx, *nodeID)
-	if err != nil {
-		return nil, fmt.Errorf("fetching node: %w", err)
 	}
 	if item.Node.TypeEnc == nil {
 		return nil, fmt.Errorf("%s is a folder — use `ls` to browse it", src.Path)
@@ -771,7 +800,7 @@ func DownloadFromDataroom(
 
 	name, err := crypto.DecryptToString(item.Node.NameEnc, sess.Identity)
 	if err != nil {
-		name = *nodeID
+		name = item.Node.ID
 	}
 
 	if err := DownloadChunks(


### PR DESCRIPTION
…d list format)