### PR TITLE
:bug: Harden the WebDAV cache layer for staleness and concurrent clients

### DIFF
--- a/cmd/webdav.go
+++ b/cmd/webdav.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -86,6 +87,18 @@ func (fi *webdavFileInfo) Mode() os.FileMode {
 	}
 
 	return 0644
+}
+
+// ETag implements webdav.ETager. The version ID identifies the file's content
+// exactly, whereas the x/net/webdav default (ModTime+Size) gives two versions of
+// equal size the same ETag and lets clients keep stale content. Folders and
+// versionless nodes fall back to the default.
+func (fi *webdavFileInfo) ETag(_ context.Context) (string, error) {
+	if fi.isDir || fi.versionID == "" {
+		return "", webdav.ErrNotImplemented
+	}
+
+	return `"` + fi.versionID + `"`, nil
 }
 
 // ContentType implements the webdav.ContentTyper interface, avoiding file downloads during PROPFIND.
@@ -277,11 +290,18 @@ func (c *dataroomCache) allNames(ctx context.Context) ([]string, error) {
 	return e.names, nil
 }
 
-// dirHandle is a webdav.File for directories. It holds a pre-built list of entries.
+// dirHandle is a webdav.File for directories.
+//
+// Entries are either given up front (static sections) or produced by load on the
+// first Readdir. Laziness matters: PROPFIND opens every listed resource just to
+// Stat it (x/net/webdav props()), and only walkFS goes on to Readdir — listing
+// children eagerly would cost one API listing per sub-folder per PROPFIND.
 type dirHandle struct {
 	info    os.FileInfo
 	entries []os.FileInfo
 	offset  int
+	load    func() ([]os.FileInfo, error) // nil = entries already populated
+	loaded  bool
 }
 
 func (h *dirHandle) Close() error                       { return nil }
@@ -290,6 +310,14 @@ func (h *dirHandle) Write(_ []byte) (int, error)        { return 0, os.ErrPermis
 func (h *dirHandle) Seek(_ int64, _ int) (int64, error) { return 0, os.ErrPermission }
 func (h *dirHandle) Stat() (os.FileInfo, error)         { return h.info, nil }
 func (h *dirHandle) Readdir(count int) ([]os.FileInfo, error) {
+	if h.load != nil && !h.loaded {
+		entries, err := h.load()
+		if err != nil {
+			return nil, err
+		}
+		h.entries = entries
+		h.loaded = true
+	}
 	if count <= 0 {
 		result := h.entries[h.offset:]
 		h.offset = len(h.entries)
@@ -318,6 +346,7 @@ type readFileHandle struct {
 	drID       string
 	versionID  string // avoids a GetDataroomNode round-trip on download
 	chunkCount int
+	parentURI  string // retyc://id/parent — the listing this handle was built from
 	info       os.FileInfo
 	// Buffered path (set by ensureDownloaded)
 	file    *os.File
@@ -351,7 +380,7 @@ func (h *readFileHandle) ensureDownloaded() error {
 		},
 	)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "webdav: download error (%s): %v\n", name, err)
+		h.onDownloadError(err)
 		_ = os.RemoveAll(tempDir)
 
 		return err
@@ -387,10 +416,38 @@ func (h *readFileHandle) startStream() error {
 				return h.wfs.client.DownloadDataroomChunk(ctx, h.versionID, chunkID)
 			},
 		)
+		if err != nil && !isClientGoneErr(err) {
+			h.onDownloadError(err)
+		}
 		_ = pipeW.CloseWithError(err)
 	}()
 
 	return nil
+}
+
+// isClientGoneErr reports whether err comes from the reader side going away — a
+// client disconnect, or a Range seek tearing the stream down in Seek — rather than
+// from a genuine download failure. Both surface on the writer side of the pipe.
+func isClientGoneErr(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, io.ErrClosedPipe)
+}
+
+// onDownloadError reports a failed chunk download and drops the cached listing of
+// the file's parent directory.
+//
+// That listing is what supplied this handle's versionID, so a download failure
+// means it may describe a node that no longer exists — typically deleted from the
+// web app or another client, which never goes through invalidateNodeCache. Without
+// this, every read for the rest of nodeCacheTTL replays the dead version and dies
+// mid-body: http.ServeContent has already committed 200 plus the stale
+// Content-Length by the time the first chunk is fetched, so the client sees a
+// truncated response and reports an I/O error. Dropping the entry makes the next
+// request re-list and answer a clean 404.
+func (h *readFileHandle) onDownloadError(err error) {
+	fmt.Fprintf(os.Stderr, "webdav: download error (%s): %v\n", h.info.Name(), err)
+	if h.parentURI != "" {
+		h.wfs.invalidateNodeCache(h.parentURI)
+	}
 }
 
 func (h *readFileHandle) Close() error {
@@ -453,15 +510,14 @@ func (h *readFileHandle) Readdir(_ int) ([]os.FileInfo, error) { return nil, os.
 // writeFileHandle is a webdav.File for uploading a file. Writes accumulate in a temp file;
 // Close uploads the temp file then deletes the temp directory.
 type writeFileHandle struct {
-	file             *os.File
-	tempDir          string
-	tempFilePath     string
-	parentURI        string // retyc://id/parent — passed to UploadToDataroom
-	wfs              *webdavFS
-	cfg              *config.Config
-	client           *api.Client
-	passphraseReader service.PassphraseReader
-	isPut            bool // true = real PUT; false = LOCK-driven create
+	file         *os.File
+	tempDir      string
+	tempFilePath string
+	drID         string
+	parentPath   string
+	parentURI    string // retyc://id/parent — key of the listing to invalidate
+	wfs          *webdavFS
+	isPut        bool // true = real PUT; false = LOCK-driven create
 }
 
 func (h *writeFileHandle) Close() error {
@@ -482,13 +538,15 @@ func (h *writeFileHandle) Close() error {
 			return nil
 		}
 	}
-	err := service.UploadToDataroom(
-		context.Background(),
-		h.cfg, h.client,
-		[]string{h.tempFilePath},
-		h.parentURI,
-		h.passphraseReader,
-		nil,
+	ctx := context.Background()
+	sess, err := h.wfs.getSession(ctx, h.drID)
+	if err != nil {
+		_ = os.RemoveAll(h.tempDir)
+
+		return fmt.Errorf("dataroom session: %w", err)
+	}
+	err = service.UploadToDataroomWithSession(
+		ctx, h.wfs.client, h.drID, h.parentPath, []string{h.tempFilePath}, sess, nil,
 	)
 	_ = os.RemoveAll(h.tempDir)
 	if err == nil {
@@ -509,6 +567,15 @@ type nodeCacheEntry struct {
 	fetchedAt time.Time
 }
 
+// nodeFetch is an in-flight listing shared by every caller that misses the cache
+// for the same URI while it runs (single-flight). nodes/err are written once,
+// before done is closed.
+type nodeFetch struct {
+	done  chan struct{}
+	nodes []service.DataroomNodeInfo
+	err   error
+}
+
 // sessionCacheEntry caches a resolved dataroom session (2 API calls + AGE crypto).
 type sessionCacheEntry struct {
 	sess      *service.DataroomSession
@@ -527,10 +594,16 @@ type webdavFS struct {
 	client           *api.Client
 	cache            *dataroomCache
 	passphraseReader service.PassphraseReader
-	nodeMu           sync.RWMutex
-	nodeCache        map[string]*nodeCacheEntry
-	sessMu           sync.RWMutex
-	sessionCache     map[string]*sessionCacheEntry
+	// listFn performs the actual listing; nil means fetchNodes (tests inject a fake).
+	listFn func(ctx context.Context, drID, nodePath string) ([]service.DataroomNodeInfo, error)
+
+	nodeMu       sync.Mutex
+	nodeCache    map[string]*nodeCacheEntry
+	nodeGen      map[string]uint64    // bumped by every invalidation of that URI
+	nodeInflight map[string]*nodeFetch // listings currently running, by URI
+
+	sessMu       sync.RWMutex
+	sessionCache map[string]*sessionCacheEntry
 }
 
 var _ webdav.FileSystem = (*webdavFS)(nil)
@@ -538,9 +611,18 @@ var _ webdav.FileSystem = (*webdavFS)(nil)
 // invalidateNodeCache removes uri from the node listing cache.
 // Called after any mutation (upload, mkdir, delete, rename) so that the next
 // PROPFIND or Stat on the affected directory fetches fresh data from the API.
+//
+// It also bumps the URI's generation so that a listing already in flight — which
+// may have been answered by the API before the mutation landed — is not stored
+// on completion (see listNodes). Without that, a read racing a write from
+// another client could pin a pre-mutation listing for a whole TTL.
 func (fs *webdavFS) invalidateNodeCache(uri string) {
 	fs.nodeMu.Lock()
 	delete(fs.nodeCache, uri)
+	if fs.nodeGen == nil {
+		fs.nodeGen = make(map[string]uint64)
+	}
+	fs.nodeGen[uri]++
 	fs.nodeMu.Unlock()
 }
 
@@ -572,37 +654,65 @@ func (fs *webdavFS) getSession(ctx context.Context, drID string) (*service.Datar
 }
 
 // listNodes returns the decrypted children of drID at nodePath, using a TTL cache.
-// Uses the session cache to avoid redundant resolveDataroomSession calls.
+//
+// Cache misses are single-flighted: concurrent callers for the same URI (a file
+// manager fires PROPFINDs in parallel) share one API listing instead of each
+// running their own. The result is stored only if the URI was not invalidated
+// while the listing ran, so a mutation that lands mid-fetch wins.
 func (fs *webdavFS) listNodes(ctx context.Context, drID, nodePath string) ([]service.DataroomNodeInfo, error) {
 	uri := dataroomURI(drID, nodePath)
 
-	fs.nodeMu.RLock()
+	fs.nodeMu.Lock()
 	if e, ok := fs.nodeCache[uri]; ok && time.Since(e.fetchedAt) < nodeCacheTTL {
-		nodes := e.nodes
-		fs.nodeMu.RUnlock()
+		fs.nodeMu.Unlock()
 
-		return nodes, nil
+		return e.nodes, nil
 	}
-	fs.nodeMu.RUnlock()
+	if f, ok := fs.nodeInflight[uri]; ok {
+		fs.nodeMu.Unlock()
+		select {
+		case <-f.done:
+			return f.nodes, f.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	f := &nodeFetch{done: make(chan struct{})}
+	if fs.nodeInflight == nil {
+		fs.nodeInflight = make(map[string]*nodeFetch)
+	}
+	fs.nodeInflight[uri] = f
+	gen := fs.nodeGen[uri]
+	fs.nodeMu.Unlock()
 
+	fetch := fs.listFn
+	if fetch == nil {
+		fetch = fs.fetchNodes
+	}
+	f.nodes, f.err = fetch(ctx, drID, nodePath)
+
+	fs.nodeMu.Lock()
+	delete(fs.nodeInflight, uri)
+	if f.err == nil && fs.nodeGen[uri] == gen {
+		if fs.nodeCache == nil {
+			fs.nodeCache = make(map[string]*nodeCacheEntry)
+		}
+		fs.nodeCache[uri] = &nodeCacheEntry{nodes: f.nodes, fetchedAt: time.Now()}
+	}
+	fs.nodeMu.Unlock()
+	close(f.done)
+
+	return f.nodes, f.err
+}
+
+// fetchNodes is the real listing behind listNodes: cached session + API walk.
+func (fs *webdavFS) fetchNodes(ctx context.Context, drID, nodePath string) ([]service.DataroomNodeInfo, error) {
 	sess, err := fs.getSession(ctx, drID)
 	if err != nil {
 		return nil, err
 	}
 
-	nodes, err := service.ListNodesWithSession(ctx, fs.client, drID, nodePath, sess)
-	if err != nil {
-		return nil, err
-	}
-
-	fs.nodeMu.Lock()
-	if fs.nodeCache == nil {
-		fs.nodeCache = make(map[string]*nodeCacheEntry)
-	}
-	fs.nodeCache[uri] = &nodeCacheEntry{nodes: nodes, fetchedAt: time.Now()}
-	fs.nodeMu.Unlock()
-
-	return nodes, nil
+	return service.ListNodesWithSession(ctx, fs.client, drID, nodePath, sess)
 }
 
 // nodesToFileInfos converts a slice of DataroomNodeInfo to []os.FileInfo.
@@ -621,6 +731,10 @@ func nodesToFileInfos(nodes []service.DataroomNodeInfo) []os.FileInfo {
 			name:        n.Name,
 			size:        n.Size,
 			isDir:       n.Type == "dir",
+			modTime:     n.ModTime(),
+			nodeID:      n.ID,
+			versionID:   n.VersionID,
+			chunkCount:  n.ChunkCount,
 			contentType: n.MIMEType,
 		})
 	}
@@ -665,8 +779,9 @@ func (fs *webdavFS) OpenFile(ctx context.Context, name string, flag int, perm os
 	if wfi.isDir {
 		return fs.openNodeDir(ctx, wfi.name, drID, subPath)
 	}
+	parentPath, _ := splitWebdavPath(subPath)
 
-	return fs.openForRead(ctx, drID, wfi)
+	return fs.openForRead(ctx, drID, parentPath, wfi)
 }
 
 // openRootDir lists the static top-level sections ("dataroom" for now).
@@ -697,24 +812,29 @@ func (fs *webdavFS) openDataroomRootDir(ctx context.Context) (webdav.File, error
 }
 
 func (fs *webdavFS) openNodeDir(ctx context.Context, displayName, drID, subPath string) (webdav.File, error) {
-	nodes, err := fs.listNodes(ctx, drID, subPath)
-	if err != nil {
-		return nil, err
-	}
-
 	return &dirHandle{
-		info:    &webdavFileInfo{name: displayName, isDir: true},
-		entries: nodesToFileInfos(nodes),
+		info: &webdavFileInfo{name: displayName, isDir: true},
+		load: func() ([]os.FileInfo, error) {
+			nodes, err := fs.listNodes(ctx, drID, subPath)
+			if err != nil {
+				return nil, err
+			}
+
+			return nodesToFileInfos(nodes), nil
+		},
 	}, nil
 }
 
-func (fs *webdavFS) openForRead(ctx context.Context, drID string, wfi *webdavFileInfo) (webdav.File, error) {
+func (fs *webdavFS) openForRead(
+	ctx context.Context, drID, parentPath string, wfi *webdavFileInfo,
+) (webdav.File, error) {
 	return &readFileHandle{
 		ctx:        ctx,
 		wfs:        fs,
 		drID:       drID,
 		versionID:  wfi.versionID,
 		chunkCount: wfi.chunkCount,
+		parentURI:  dataroomURI(drID, parentPath),
 		info:       wfi,
 	}, nil
 }
@@ -735,15 +855,14 @@ func (fs *webdavFS) openForWriteTempFile(drID, parentPath, fileName string, isPu
 	}
 
 	return &writeFileHandle{
-		file:             f,
-		tempDir:          tempDir,
-		tempFilePath:     tempFilePath,
-		parentURI:        dataroomURI(drID, parentPath),
-		wfs:              fs,
-		cfg:              fs.cfg,
-		client:           fs.client,
-		passphraseReader: fs.passphraseReader,
-		isPut:            isPut,
+		file:         f,
+		tempDir:      tempDir,
+		tempFilePath: tempFilePath,
+		drID:         drID,
+		parentPath:   parentPath,
+		parentURI:    dataroomURI(drID, parentPath),
+		wfs:          fs,
+		isPut:        isPut,
 	}, nil
 }
 
@@ -848,7 +967,8 @@ func (fs *webdavFS) openForWriteStream(
 		pipeW:     pipeW,
 		done:      done,
 		parentURI: dataroomURI(drID, parentPath),
-		info:      &webdavFileInfo{name: fileName, size: size},
+		// versionID lets the PUT response carry the new version's ETag.
+		info: &webdavFileInfo{name: fileName, size: size, nodeID: nodeID, versionID: versionID},
 	}, nil
 }
 
@@ -874,7 +994,11 @@ func (fs *webdavFS) Mkdir(ctx context.Context, name string, _ os.FileMode) error
 	if err != nil {
 		return err
 	}
-	_, err = service.MkdirDataroom(ctx, fs.cfg, fs.client, dataroomURI(drID, subPath), fs.passphraseReader)
+	sess, err := fs.getSession(ctx, drID)
+	if err != nil {
+		return fmt.Errorf("dataroom session: %w", err)
+	}
+	_, err = service.MkdirDataroomWithSession(ctx, fs.client, drID, subPath, sess)
 	if err == nil {
 		parentPath, _ := splitWebdavPath(subPath)
 		fs.invalidateNodeCache(dataroomURI(drID, parentPath))
@@ -893,7 +1017,11 @@ func (fs *webdavFS) RemoveAll(ctx context.Context, name string) error {
 	if err != nil {
 		return err
 	}
-	_, err = service.DeleteDataroomNode(ctx, fs.cfg, fs.client, dataroomURI(drID, subPath), fs.passphraseReader)
+	sess, err := fs.getSession(ctx, drID)
+	if err != nil {
+		return fmt.Errorf("dataroom session: %w", err)
+	}
+	_, err = service.DeleteDataroomNodeWithSession(ctx, fs.client, drID, subPath, sess)
 	if err == nil {
 		parentPath, _ := splitWebdavPath(subPath)
 		fs.invalidateNodeCache(dataroomURI(drID, parentPath))
@@ -923,12 +1051,11 @@ func (fs *webdavFS) Rename(ctx context.Context, oldName, newName string) error {
 		return fmt.Errorf("moving between datarooms is not supported: %w", os.ErrPermission)
 	}
 
-	err = service.MoveDataroomNode(
-		ctx, fs.cfg, fs.client,
-		dataroomURI(oldID, oldSub),
-		dataroomURI(newID, newSub),
-		fs.passphraseReader,
-	)
+	sess, err := fs.getSession(ctx, oldID)
+	if err != nil {
+		return fmt.Errorf("dataroom session: %w", err)
+	}
+	err = service.MoveDataroomNodeWithSession(ctx, fs.client, oldID, oldSub, newSub, sess)
 	if err == nil {
 		oldParent, _ := splitWebdavPath(oldSub)
 		fs.invalidateNodeCache(dataroomURI(oldID, oldParent))
@@ -973,6 +1100,7 @@ func (fs *webdavFS) Stat(ctx context.Context, name string) (os.FileInfo, error) 
 				name:        n.Name,
 				size:        n.Size,
 				isDir:       n.Type == "dir",
+				modTime:     n.ModTime(),
 				nodeID:      n.ID,
 				versionID:   n.VersionID,
 				chunkCount:  n.ChunkCount,

--- a/cmd/webdav_test.go
+++ b/cmd/webdav_test.go
@@ -3,13 +3,24 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"golang.org/x/net/webdav"
+	"golang.org/x/oauth2"
+
+	"github.com/retyc/retyc-cli/internal/api"
+	"github.com/retyc/retyc-cli/internal/crypto"
+	"github.com/retyc/retyc-cli/internal/service"
 )
 
 // — webdavFileInfo ————————————————————————————————————————————————————————————
@@ -390,4 +401,433 @@ func TestDataroomCache_AllNames(t *testing.T) {
 	if len(names) != 2 || names[0] != "Alpha" || names[1] != "Zebra" {
 		t.Errorf("allNames() = %v, want [Alpha Zebra]", names)
 	}
+}
+
+// — Stale listing cache after an out-of-band delete ————————————————————————————
+
+// newWebdavTestFS builds a webdavFS whose API client points at srv, with the
+// listing and session caches pre-warmed for dataroom "dr1" — the state the server
+// is in when a file is deleted from the web app while our cache is still warm.
+func newWebdavTestFS(srv *httptest.Server) *webdavFS {
+	client := api.New(srv.URL, "retyc-test/1.0", oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: "test-token",
+		TokenType:   "Bearer",
+		Expiry:      time.Now().Add(time.Hour),
+	}), false, false)
+
+	return &webdavFS{
+		client: client,
+		nodeCache: map[string]*nodeCacheEntry{
+			"retyc://dr1/": {
+				nodes:     []service.DataroomNodeInfo{{ID: "n1", Name: "log.txt", Type: "file"}},
+				fetchedAt: time.Now(),
+			},
+		},
+		sessionCache: map[string]*sessionCacheEntry{
+			"dr1": {sess: &service.DataroomSession{}, fetchedAt: time.Now()},
+		},
+	}
+}
+
+// newStaleReadHandle returns a handle built from the stale listing: its versionID
+// points at a node that no longer exists server-side.
+func newStaleReadHandle(fs *webdavFS) *readFileHandle {
+	return &readFileHandle{
+		ctx:        context.Background(),
+		wfs:        fs,
+		drID:       "dr1",
+		versionID:  "v-deleted",
+		chunkCount: 1,
+		parentURI:  "retyc://dr1/",
+		info:       &webdavFileInfo{name: "log.txt", size: 42},
+	}
+}
+
+func nodeCacheHas(fs *webdavFS, uri string) bool {
+	fs.nodeMu.Lock()
+	defer fs.nodeMu.Unlock()
+	_, ok := fs.nodeCache[uri]
+
+	return ok
+}
+
+func notFoundServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "node not found", http.StatusNotFound)
+	}))
+}
+
+// TestReadFileHandle_StreamErrorInvalidatesNodeCache covers the streaming read path:
+// a failed chunk download must drop the parent listing from the cache so the next
+// request re-lists and answers 404, instead of replaying the dead version for the
+// rest of nodeCacheTTL.
+func TestReadFileHandle_StreamErrorInvalidatesNodeCache(t *testing.T) {
+	srv := notFoundServer()
+	defer srv.Close()
+
+	fs := newWebdavTestFS(srv)
+	h := newStaleReadHandle(fs)
+
+	if _, err := h.Read(make([]byte, 16)); err == nil {
+		t.Fatal("Read() = nil error, want the 404 from the chunk download")
+	}
+	if nodeCacheHas(fs, "retyc://dr1/") {
+		t.Error("listing cache entry still present after a failed chunk download")
+	}
+}
+
+// TestReadFileHandle_BufferedErrorInvalidatesNodeCache covers the buffered read path,
+// which a Range request takes (Seek to a non-zero offset).
+func TestReadFileHandle_BufferedErrorInvalidatesNodeCache(t *testing.T) {
+	srv := notFoundServer()
+	defer srv.Close()
+
+	fs := newWebdavTestFS(srv)
+	h := newStaleReadHandle(fs)
+
+	if _, err := h.Seek(8, io.SeekStart); err == nil {
+		t.Fatal("Seek() = nil error, want the 404 from the chunk download")
+	}
+	if nodeCacheHas(fs, "retyc://dr1/") {
+		t.Error("listing cache entry still present after a failed chunk download")
+	}
+}
+
+// TestIsClientGoneErr guards against invalidating the cache when the reader side
+// simply went away (client disconnect, or a Range seek tearing down the stream) —
+// that is not evidence the node was deleted.
+func TestIsClientGoneErr(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{fmt.Errorf("writing chunk 0: %w", context.Canceled), true},
+		{fmt.Errorf("writing chunk 0: %w", io.ErrClosedPipe), true},
+		{errors.New("downloading chunk 0: API error 404: node not found"), false},
+		{nil, false},
+	}
+	for _, c := range cases {
+		if got := isClientGoneErr(c.err); got != c.want {
+			t.Errorf("isClientGoneErr(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+// — dirHandle: lazy listing ———————————————————————————————————————————————————
+
+// PROPFIND calls OpenFile + Stat + Close on every listed resource (x/net/webdav
+// props()); only walkFS goes on to Readdir. A directory handle must therefore
+// not list its children until Readdir is actually called, or listing a folder
+// with K sub-folders costs K extra API listings.
+func TestDirHandle_LazyLoad(t *testing.T) {
+	calls := 0
+	h := &dirHandle{
+		info: &webdavFileInfo{name: "d", isDir: true},
+		load: func() ([]os.FileInfo, error) {
+			calls++
+
+			return []os.FileInfo{&webdavFileInfo{name: "a"}, &webdavFileInfo{name: "b"}}, nil
+		},
+	}
+
+	if _, err := h.Stat(); err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("Stat() triggered the listing (%d calls); it must stay lazy until Readdir", calls)
+	}
+
+	first, err := h.Readdir(1)
+	if err != nil || len(first) != 1 || first[0].Name() != "a" {
+		t.Fatalf("Readdir(1) = (%v, %v), want [a]", first, err)
+	}
+	rest, err := h.Readdir(0)
+	if err != nil || len(rest) != 1 || rest[0].Name() != "b" {
+		t.Fatalf("Readdir(0) = (%v, %v), want [b]", rest, err)
+	}
+	if _, err := h.Readdir(1); err != io.EOF {
+		t.Errorf("Readdir(1) at end = %v, want io.EOF", err)
+	}
+	if calls != 1 {
+		t.Errorf("listing fetched %d times, want exactly 1", calls)
+	}
+}
+
+func TestDirHandle_LoadError(t *testing.T) {
+	want := errors.New("listing failed")
+	h := &dirHandle{
+		info: &webdavFileInfo{name: "d", isDir: true},
+		load: func() ([]os.FileInfo, error) { return nil, want },
+	}
+	if _, err := h.Stat(); err != nil {
+		t.Fatalf("Stat() error = %v, want nil (no listing needed)", err)
+	}
+	if _, err := h.Readdir(0); !errors.Is(err, want) {
+		t.Errorf("Readdir() error = %v, want %v", err, want)
+	}
+}
+
+// Static handles (root, dataroom index) are built with entries and no loader.
+func TestDirHandle_StaticEntries(t *testing.T) {
+	h := &dirHandle{
+		info:    &webdavFileInfo{name: "/", isDir: true},
+		entries: []os.FileInfo{&webdavFileInfo{name: "dataroom", isDir: true}},
+	}
+	got, err := h.Readdir(0)
+	if err != nil || len(got) != 1 {
+		t.Fatalf("Readdir(0) = (%v, %v), want 1 entry", got, err)
+	}
+}
+
+// — ETag / Last-Modified ——————————————————————————————————————————————————————
+
+// The ETag is the client's freshness signal. The x/net/webdav default derives it
+// from ModTime+Size, which collapses two versions of equal size into one ETag; the
+// version ID is a true content identifier, so it must be used for files.
+func TestWebdavFileInfo_ETag(t *testing.T) {
+	ctx := context.Background()
+
+	file := &webdavFileInfo{name: "f.txt", size: 5, versionID: "v-123"}
+	etag, err := file.ETag(ctx)
+	if err != nil {
+		t.Fatalf("ETag() error = %v", err)
+	}
+	if etag != `"v-123"` {
+		t.Errorf("ETag() = %s, want %s", etag, `"v-123"`)
+	}
+
+	dir := &webdavFileInfo{name: "d", isDir: true}
+	if _, err := dir.ETag(ctx); !errors.Is(err, webdav.ErrNotImplemented) {
+		t.Errorf("dir ETag() error = %v, want webdav.ErrNotImplemented (fall back to default)", err)
+	}
+	versionless := &webdavFileInfo{name: "empty"}
+	if _, err := versionless.ETag(ctx); !errors.Is(err, webdav.ErrNotImplemented) {
+		t.Errorf("versionless ETag() error = %v, want webdav.ErrNotImplemented", err)
+	}
+}
+
+// Stat and directory listings must carry the version time through so that
+// PROPFIND getlastmodified and GET Last-Modified are meaningful.
+func TestWebdavFS_StatCarriesModTime(t *testing.T) {
+	created := time.Date(2026, 9, 4, 10, 30, 0, 0, time.UTC)
+	fileNode := service.DataroomNodeInfo{ID: "n1", Name: "f.txt", Type: "file", VersionID: "v1"}.WithModTime(created)
+	fs := &webdavFS{
+		cache: newDataroomCache(func(_ context.Context) ([]dataroomCacheItem, error) {
+			return []dataroomCacheItem{{id: "dr1", title: "DR"}}, nil
+		}),
+		nodeCache: map[string]*nodeCacheEntry{
+			"retyc://dr1/": {
+				nodes:     []service.DataroomNodeInfo{fileNode},
+				fetchedAt: time.Now(),
+			},
+		},
+	}
+
+	info, err := fs.Stat(context.Background(), "/dataroom/DR/f.txt")
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if !info.ModTime().Equal(created) {
+		t.Errorf("Stat().ModTime() = %v, want %v", info.ModTime(), created)
+	}
+	entries := nodesToFileInfos([]service.DataroomNodeInfo{fileNode})
+	if len(entries) != 1 || !entries[0].ModTime().Equal(created) {
+		t.Errorf("nodesToFileInfos ModTime = %v, want %v", entries[0].ModTime(), created)
+	}
+}
+
+// — Mutations reuse the cached session ————————————————————————————————————————
+
+// Every mutation used to re-resolve the dataroom session (2 API calls + AGE
+// crypto) although the server already caches it. With the session cache warm,
+// MKCOL / DELETE / MOVE must hit only the node endpoints.
+func TestWebdavFS_MutationsUseCachedSession(t *testing.T) {
+	identity, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	pub := identity.Recipient().String()
+	xNameEnc, err := crypto.EncryptStringForKeys("x", []string{pub})
+	if err != nil {
+		t.Fatalf("EncryptStringForKeys: %v", err)
+	}
+
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		switch {
+		case r.URL.Path == "/dataroom/dr1" || r.URL.Path == "/user/me/key/active":
+			t.Errorf("session re-resolved through %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected", http.StatusInternalServerError)
+		case r.Method == http.MethodPost && r.URL.Path == "/dataroom/dr1/node":
+			fmt.Fprint(w, `{"id":"n-new","name_enc":"x"}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/dataroom/dr1/nodes":
+			fmt.Fprintf(w, `{"items":[{"node":{"id":"n-x","name_enc":%q,"type_enc":null,"parent_id":null},`+
+				`"node_version":null}],"total":1,"pages":1,"page":1}`, xNameEnc)
+		case r.Method == http.MethodDelete && r.URL.Path == "/dataroom/node/n-x":
+			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodPut && r.URL.Path == "/dataroom/node/n-x":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.Path, http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	fs := newWebdavTestFS(srv)
+	fs.cache = newDataroomCache(func(_ context.Context) ([]dataroomCacheItem, error) {
+		return []dataroomCacheItem{{id: "dr1", title: "DR"}}, nil
+	})
+	fs.sessionCache["dr1"] = &sessionCacheEntry{
+		sess:      &service.DataroomSession{Identity: identity, PublicKey: pub},
+		fetchedAt: time.Now(),
+	}
+	ctx := context.Background()
+
+	if err := fs.Mkdir(ctx, "/dataroom/DR/newdir", 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if nodeCacheHas(fs, "retyc://dr1/") {
+		t.Error("Mkdir did not invalidate the parent listing")
+	}
+	if err := fs.Rename(ctx, "/dataroom/DR/x", "/dataroom/DR/y"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if err := fs.RemoveAll(ctx, "/dataroom/DR/x"); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	for _, c := range calls {
+		if strings.HasPrefix(c, "GET /dataroom/dr1/nodes") || strings.HasPrefix(c, "POST /dataroom/dr1/node") ||
+			strings.HasPrefix(c, "DELETE /dataroom/node/") || strings.HasPrefix(c, "PUT /dataroom/node/") {
+			continue
+		}
+		t.Errorf("unexpected API call %s", c)
+	}
+}
+
+// — listNodes: single-flight + generation check ———————————————————————————————
+
+// gatedListFn returns a listFn that blocks on gate and counts its calls.
+// started is signalled once per call, before blocking.
+func gatedListFn(t *testing.T, gate <-chan struct{}, started chan<- struct{}) (
+	func(context.Context, string, string) ([]service.DataroomNodeInfo, error), *int32,
+) {
+	t.Helper()
+	var calls int32
+
+	return func(_ context.Context, _, _ string) ([]service.DataroomNodeInfo, error) {
+		atomic.AddInt32(&calls, 1)
+		started <- struct{}{}
+		<-gate
+
+		return []service.DataroomNodeInfo{{ID: "n1", Name: "a", Type: "file"}}, nil
+	}, &calls
+}
+
+func TestListNodes_CacheHit(t *testing.T) {
+	gate := make(chan struct{})
+	close(gate)
+	started := make(chan struct{}, 8)
+	listFn, calls := gatedListFn(t, gate, started)
+	fs := &webdavFS{listFn: listFn}
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		if _, err := fs.listNodes(ctx, "dr1", "/"); err != nil {
+			t.Fatalf("listNodes: %v", err)
+		}
+	}
+	if n := atomic.LoadInt32(calls); n != 1 {
+		t.Errorf("listing fetched %d times for 3 sequential calls, want 1", n)
+	}
+}
+
+// Concurrent misses on the same URI must share one fetch.
+func TestListNodes_SingleFlight(t *testing.T) {
+	gate := make(chan struct{})
+	started := make(chan struct{}, 8)
+	listFn, calls := gatedListFn(t, gate, started)
+	fs := &webdavFS{listFn: listFn}
+	ctx := context.Background()
+
+	const n = 5
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			nodes, err := fs.listNodes(ctx, "dr1", "/")
+			if err == nil && len(nodes) != 1 {
+				err = fmt.Errorf("got %d nodes, want 1", len(nodes))
+			}
+			errs <- err
+		}()
+	}
+	<-started // the leader is inside the fetch; everyone else either joins it or hits the cache after
+	close(gate)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Error(err)
+		}
+	}
+	if got := atomic.LoadInt32(calls); got != 1 {
+		t.Errorf("listing fetched %d times for %d concurrent callers, want 1", got, n)
+	}
+}
+
+// A listing answered before a mutation landed must not be stored after that
+// mutation invalidated the URI — otherwise a read racing a write from another
+// client pins a pre-mutation listing for a whole TTL.
+func TestListNodes_InvalidatedDuringFetchIsNotCached(t *testing.T) {
+	gate := make(chan struct{})
+	started := make(chan struct{}, 8)
+	listFn, calls := gatedListFn(t, gate, started)
+	fs := &webdavFS{listFn: listFn}
+	ctx := context.Background()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := fs.listNodes(ctx, "dr1", "/")
+		done <- err
+	}()
+	<-started
+	fs.invalidateNodeCache("retyc://dr1/") // mutation lands while the listing is in flight
+	close(gate)
+	if err := <-done; err != nil {
+		t.Fatalf("listNodes: %v", err)
+	}
+	if nodeCacheHas(fs, "retyc://dr1/") {
+		t.Fatal("listing that raced an invalidation was stored in the cache")
+	}
+	// The next call must fetch again.
+	if _, err := fs.listNodes(ctx, "dr1", "/"); err != nil {
+		t.Fatalf("listNodes (refetch): %v", err)
+	}
+	if got := atomic.LoadInt32(calls); got != 2 {
+		t.Errorf("listing fetched %d times, want 2 (first result discarded, second stored)", got)
+	}
+	if !nodeCacheHas(fs, "retyc://dr1/") {
+		t.Error("clean refetch was not stored")
+	}
+}
+
+// A waiter whose own context is cancelled must not block on the leader.
+func TestListNodes_WaiterHonoursContext(t *testing.T) {
+	gate := make(chan struct{})
+	started := make(chan struct{}, 8)
+	listFn, _ := gatedListFn(t, gate, started)
+	fs := &webdavFS{listFn: listFn}
+
+	go func() { _, _ = fs.listNodes(context.Background(), "dr1", "/") }()
+	<-started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := fs.listNodes(ctx, "dr1", "/"); !errors.Is(err, context.Canceled) {
+		t.Errorf("waiter error = %v, want context.Canceled", err)
+	}
+	close(gate)
 }

--- a/doc/webdav.md
+++ b/doc/webdav.md
@@ -95,6 +95,14 @@ Notes and limitations:
 - Listings and dataroom sessions are cached briefly (30 s / 30 min respectively);
   mutations made through the server invalidate the relevant cache immediately, but
   changes made elsewhere (web app, another client) may take up to a minute to appear.
+  A read that fails because the cached listing pointed at a deleted node drops that
+  listing straight away, so the following request sees the current state (`404`)
+  rather than replaying the stale entry until the TTL expires. Concurrent requests
+  for the same folder share a single listing, and a listing that was in flight when
+  a mutation landed is discarded rather than cached.
+- Files expose the version ID as their `ETag` and the version's creation time as
+  `Last-Modified`, so clients can detect a new version even when the size is
+  unchanged. Folders have no timestamp in the API and report none.
 
 ## Authentication (`--auth`)
 

--- a/internal/service/dataroom.go
+++ b/internal/service/dataroom.go
@@ -213,6 +213,7 @@ func nodesFromItems(items []api.DataroomNodeItem, identity *age.HybridIdentity) 
 		var versionID string
 		var chunkCount int
 		var mimeType string
+		var modTime time.Time
 		if item.Node.TypeEnc != nil {
 			nodeType = "file"
 			mimeType, _ = crypto.DecryptToString(*item.Node.TypeEnc, identity)
@@ -220,6 +221,7 @@ func nodesFromItems(items []api.DataroomNodeItem, identity *age.HybridIdentity) 
 				size = item.Version.OriginalSize
 				versionID = item.Version.ID
 				chunkCount = item.Version.ChunkCount
+				modTime = item.Version.CreatedAt
 			}
 		}
 		result = append(result, DataroomNodeInfo{
@@ -230,6 +232,7 @@ func nodesFromItems(items []api.DataroomNodeItem, identity *age.HybridIdentity) 
 			Size:       size,
 			VersionID:  versionID,
 			ChunkCount: chunkCount,
+			modTime:    modTime,
 		})
 	}
 
@@ -805,7 +808,16 @@ func UploadToDataroom(
 		return err
 	}
 
-	destParentID, err := resolvePath(ctx, client, dst.DataroomID, dst.Path, sess.Identity)
+	return UploadToDataroomWithSession(ctx, client, dst.DataroomID, dst.Path, localPaths, sess, progress)
+}
+
+// UploadToDataroomWithSession is UploadToDataroom for callers that already hold
+// the dataroom session (the WebDAV server caches it per dataroom).
+func UploadToDataroomWithSession(
+	ctx context.Context, client *api.Client, dataroomID, dstPath string,
+	localPaths []string, sess *DataroomSession, progress ProgressFn,
+) error {
+	destParentID, err := resolvePath(ctx, client, dataroomID, dstPath, sess.Identity)
 	if err != nil {
 		return err
 	}
@@ -817,14 +829,14 @@ func UploadToDataroom(
 		}
 		if info.IsDir() {
 			if err := uploadDataroomDir(
-				ctx, client, dst.DataroomID, localPath, destParentID,
+				ctx, client, dataroomID, localPath, destParentID,
 				sess.PublicKey, sess.Identity, sess.NameSalt, progress,
 			); err != nil {
 				return fmt.Errorf("%s: %w", info.Name(), err)
 			}
 		} else {
 			if err := uploadDataroomFile(
-				ctx, client, dst.DataroomID, localPath, destParentID,
+				ctx, client, dataroomID, localPath, destParentID,
 				sess.PublicKey, sess.Identity, "", sess.NameSalt, progress,
 			); err != nil {
 				return fmt.Errorf("%s: %w", info.Name(), err)
@@ -935,17 +947,25 @@ func MkdirDataroom(
 		return "", err
 	}
 
-	parentPath, name := splitPathParent(parsed.Path)
-	if name == "" {
-		return "", fmt.Errorf("path must include a folder name: %s", uri)
-	}
-
 	sess, err := resolveDataroomSession(ctx, cfg, client, parsed.DataroomID, reader)
 	if err != nil {
 		return "", err
 	}
 
-	parentID, err := resolvePath(ctx, client, parsed.DataroomID, parentPath, sess.Identity)
+	return MkdirDataroomWithSession(ctx, client, parsed.DataroomID, parsed.Path, sess)
+}
+
+// MkdirDataroomWithSession is MkdirDataroom for callers that already hold the
+// dataroom session.
+func MkdirDataroomWithSession(
+	ctx context.Context, client *api.Client, dataroomID, nodePath string, sess *DataroomSession,
+) (string, error) {
+	parentPath, name := splitPathParent(nodePath)
+	if name == "" {
+		return "", fmt.Errorf("path must include a folder name: %s", nodePath)
+	}
+
+	parentID, err := resolvePath(ctx, client, dataroomID, parentPath, sess.Identity)
 	if err != nil {
 		return "", err
 	}
@@ -956,7 +976,7 @@ func MkdirDataroom(
 	}
 
 	node, err := client.CreateDataroomNode(
-		ctx, parsed.DataroomID, nameEnc, nodeNameHash(name, sess.NameSalt), nil, parentID,
+		ctx, dataroomID, nameEnc, nodeNameHash(name, sess.NameSalt), nil, parentID,
 	)
 	if err != nil {
 		return "", fmt.Errorf("creating folder: %w", err)
@@ -988,13 +1008,22 @@ func DeleteDataroomNode(
 		return 0, err
 	}
 
-	if hasGlob(parsed.Path) {
-		matches, err := resolveGlob(ctx, client, parsed.DataroomID, parsed.Path, sess.Identity)
+	return DeleteDataroomNodeWithSession(ctx, client, parsed.DataroomID, parsed.Path, sess)
+}
+
+// DeleteDataroomNodeWithSession deletes the node(s) at nodePath (glob allowed)
+// for callers that already hold the dataroom session. Deleting the dataroom
+// itself ("/") needs no session and stays in DeleteDataroomNode.
+func DeleteDataroomNodeWithSession(
+	ctx context.Context, client *api.Client, dataroomID, nodePath string, sess *DataroomSession,
+) (int, error) {
+	if hasGlob(nodePath) {
+		matches, err := resolveGlob(ctx, client, dataroomID, nodePath, sess.Identity)
 		if err != nil {
 			return 0, err
 		}
 		if len(matches) == 0 {
-			return 0, fmt.Errorf("no nodes match %s", parsed.Path)
+			return 0, fmt.Errorf("no nodes match %s", nodePath)
 		}
 		for _, item := range matches {
 			if err := client.DeleteDataroomNode(ctx, item.Node.ID); err != nil {
@@ -1005,7 +1034,7 @@ func DeleteDataroomNode(
 		return len(matches), nil
 	}
 
-	nodeID, err := resolvePath(ctx, client, parsed.DataroomID, parsed.Path, sess.Identity)
+	nodeID, err := resolvePath(ctx, client, dataroomID, nodePath, sess.Identity)
 	if err != nil {
 		return 0, err
 	}
@@ -1040,7 +1069,15 @@ func MoveDataroomNode(
 		return err
 	}
 
-	srcNodeID, err := resolvePath(ctx, client, src.DataroomID, src.Path, sess.Identity)
+	return MoveDataroomNodeWithSession(ctx, client, src.DataroomID, src.Path, dst.Path, sess)
+}
+
+// MoveDataroomNodeWithSession renames/moves srcPath to dstPath within one
+// dataroom for callers that already hold the dataroom session.
+func MoveDataroomNodeWithSession(
+	ctx context.Context, client *api.Client, dataroomID, srcPath, dstPath string, sess *DataroomSession,
+) error {
+	srcNodeID, err := resolvePath(ctx, client, dataroomID, srcPath, sess.Identity)
 	if err != nil {
 		return err
 	}
@@ -1048,12 +1085,12 @@ func MoveDataroomNode(
 		return fmt.Errorf("cannot move the root folder")
 	}
 
-	dstParentPath, newName := splitPathParent(dst.Path)
+	dstParentPath, newName := splitPathParent(dstPath)
 	if newName == "" {
-		return fmt.Errorf("destination path must include a name: %s", dstURI)
+		return fmt.Errorf("destination path must include a name: %s", dstPath)
 	}
 
-	dstParentID, err := resolvePath(ctx, client, dst.DataroomID, dstParentPath, sess.Identity)
+	dstParentID, err := resolvePath(ctx, client, dataroomID, dstParentPath, sess.Identity)
 	if err != nil {
 		return err
 	}

--- a/internal/service/dataroom_test.go
+++ b/internal/service/dataroom_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/retyc/retyc-cli/internal/api"
+	"github.com/retyc/retyc-cli/internal/crypto"
 )
 
 // — ParseRetycURI —————————————————————————————————————————————————————————————
@@ -191,5 +193,45 @@ func TestIsConflict(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isConflict(%v) = %v, want %v", tt.err, got, tt.want)
 		}
+	}
+}
+
+// — nodesFromItems ————————————————————————————————————————————————————————————
+
+// TestNodesFromItems_ModTime: the version's creation time is the only
+// modification signal the API exposes; it must reach callers (WebDAV
+// Last-Modified) through the accessor without changing the marshalled shape.
+func TestNodesFromItems_ModTime(t *testing.T) {
+	identity, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("GenerateKeyPair: %v", err)
+	}
+	pub := identity.Recipient().String()
+	nameEnc, err := crypto.EncryptStringForKeys("f.txt", []string{pub})
+	if err != nil {
+		t.Fatalf("EncryptStringForKeys: %v", err)
+	}
+	typeEnc, err := crypto.EncryptStringForKeys("text/plain", []string{pub})
+	if err != nil {
+		t.Fatalf("EncryptStringForKeys: %v", err)
+	}
+	created := time.Date(2026, 9, 4, 10, 30, 0, 0, time.UTC)
+
+	nodes := nodesFromItems([]api.DataroomNodeItem{
+		{
+			Node:    api.DataroomNode{ID: "n1", NameEnc: nameEnc, TypeEnc: &typeEnc},
+			Version: &api.DataroomNodeVersion{ID: "v1", OriginalSize: 5, ChunkCount: 1, CreatedAt: created},
+		},
+		{Node: api.DataroomNode{ID: "n2", NameEnc: nameEnc}},
+	}, identity)
+
+	if len(nodes) != 2 {
+		t.Fatalf("got %d nodes, want 2", len(nodes))
+	}
+	if !nodes[0].ModTime().Equal(created) {
+		t.Errorf("file ModTime() = %v, want %v", nodes[0].ModTime(), created)
+	}
+	if !nodes[1].ModTime().IsZero() {
+		t.Errorf("dir ModTime() = %v, want zero (API exposes no timestamp for folders)", nodes[1].ModTime())
 	}
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -1,7 +1,11 @@
 // Package service contains the business logic shared between the CLI and the MCP server.
 package service
 
-import "github.com/retyc/retyc-cli/internal/api"
+import (
+	"time"
+
+	"github.com/retyc/retyc-cli/internal/api"
+)
 
 // ProgressFn is called after each chunk is processed during an upload or download.
 // filename is the file being processed, chunkBytes is the plaintext byte count for
@@ -103,4 +107,19 @@ type DataroomNodeInfo struct {
 	Size       int64
 	VersionID  string // non-empty for file nodes; the current version's ID
 	ChunkCount int    // number of encrypted chunks; used for direct download without GetDataroomNode
+	// modTime is the current version's creation time (zero for folders). Kept
+	// unexported so the JSON shape emitted by the MCP server does not change;
+	// read it through ModTime.
+	modTime time.Time
+}
+
+// ModTime returns the current version's creation time, or the zero time for
+// folders and versionless nodes.
+func (n DataroomNodeInfo) ModTime() time.Time { return n.modTime }
+
+// WithModTime returns a copy of n carrying t as its modification time.
+func (n DataroomNodeInfo) WithModTime(t time.Time) DataroomNodeInfo {
+	n.modTime = t
+
+	return n
 }


### PR DESCRIPTION
A node deleted from the web app (or any other client) never goes through invalidateNodeCache, so nodeCache kept serving its versionID for up to nodeCacheTTL. Every read in that window replayed the dead version and died mid-body: http.ServeContent has already committed 200 plus the stale Content-Length by the time the first chunk is fetched, so the client saw a truncated response and reported an I/O error — appending to a mounted file failed at open() for the whole TTL.

Auditing the rest of the cache layer around that bug turned up four more issues, fixed here as one change:

- Failed chunk download: readFileHandle now carries the parentURI it was built from and drops that listing on failure, so the next request re-lists and answers a clean 404. Applied to both read paths; the streaming one was also swallowing the error entirely. isClientGoneErr keeps a client disconnect or a Range seek tearing down the stream from being mistaken for a missing node.

- ETag / Last-Modified: webdavFileInfo never set modTime, so the default ETag (ModTime+Size) collapsed two versions of equal size into one and clients kept stale content. Files now expose the version ID as ETag (webdav.ETager) and the version's CreatedAt as Last-Modified; the PUT response carries the new ETag. DataroomNodeInfo keeps the timestamp in an unexported field with an accessor so the MCP JSON shape is unchanged.

- Lazy dirHandle: PROPFIND opens every listed resource just to Stat it (x/net/webdav props()), which listed every sub-folder's children on each PROPFIND. Directory handles now list on the first Readdir only.

- Mutations reuse the cached session: MKCOL / DELETE / MOVE / buffered PUT re-resolved the dataroom session (two API calls plus AGE crypto) on every call. New *WithSession service variants take the cached session; the existing wrappers delegate to them unchanged.

- Single-flight and generation-checked listings: concurrent misses for the same folder share one API listing, and a listing that was in flight when invalidateNodeCache ran is discarded instead of stored, so a read racing a write from another client cannot pin a pre-mutation listing for a TTL.