### PR TITLE
:zap: Resolve dataroom sessions once per process in webdav and mcp serve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@ internal/
     user.go                     # UserKey type + GetActiveKey
     admin*.go                   # Admin* types + Admin* API methods (org/member/blacklist/dataroom/transfer)
   service/
+    session_cache.go             # SessionCache (process-lifetime dataroom sessions, single-flight, one scrypt at a
+                                 #   time) + EnableSessionCache() used by mcp serve; webdav serve holds its own instance
     admin*.go                    # AdminListNodes, AdminDownloadNodes, AdminRekeyDataroom/Transfer, LoadAdminIdentity
   config/
     config.go                   # Structs, SetDefaults(), Load(), token persistence

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -60,6 +60,11 @@ Example configuration for Claude Desktop (claude_desktop_config.json):
 
 		registerMCPTools(srv)
 
+		// Resolve each dataroom session once per process: without it every tool
+		// call re-runs the scrypt that unlocks the user key (~256 MiB) whenever
+		// no keyring caches the identity (macOS, Windows, containers).
+		service.EnableSessionCache()
+
 		return server.ServeStdio(srv)
 	},
 }

--- a/cmd/webdav.go
+++ b/cmd/webdav.go
@@ -576,17 +576,8 @@ type nodeFetch struct {
 	err   error
 }
 
-// sessionCacheEntry caches a resolved dataroom session (2 API calls + AGE crypto).
-type sessionCacheEntry struct {
-	sess      *service.DataroomSession
-	fetchedAt time.Time
-}
-
 // nodeCacheTTL is longer than before because mutations now explicitly invalidate the cache.
 const nodeCacheTTL = 30 * time.Second
-
-// sessionCacheTTL: sessions only change on dataroom rekey (user add/remove), which WebDAV doesn't perform.
-const sessionCacheTTL = 30 * time.Minute
 
 // webdavFS implements webdav.FileSystem over RETYC datarooms.
 type webdavFS struct {
@@ -596,14 +587,18 @@ type webdavFS struct {
 	passphraseReader service.PassphraseReader
 	// listFn performs the actual listing; nil means fetchNodes (tests inject a fake).
 	listFn func(ctx context.Context, drID, nodePath string) ([]service.DataroomNodeInfo, error)
+	// sessionFn resolves a dataroom session; nil means service.GetDataroomSession
+	// (tests inject a fake).
+	sessionFn func(ctx context.Context, drID string) (*service.DataroomSession, error)
 
 	nodeMu       sync.Mutex
 	nodeCache    map[string]*nodeCacheEntry
 	nodeGen      map[string]uint64    // bumped by every invalidation of that URI
 	nodeInflight map[string]*nodeFetch // listings currently running, by URI
 
-	sessMu       sync.RWMutex
-	sessionCache map[string]*sessionCacheEntry
+	// sessions holds one resolved session per dataroom for the life of the
+	// process (no TTL, single-flight, one scrypt at a time — see service.SessionCache).
+	sessions service.SessionCache
 }
 
 var _ webdav.FileSystem = (*webdavFS)(nil)
@@ -626,31 +621,20 @@ func (fs *webdavFS) invalidateNodeCache(uri string) {
 	fs.nodeMu.Unlock()
 }
 
-// getSession returns the cached session for drID, resolving it on first access or after TTL expiry.
-// Caching avoids two API calls (GetDataroom + GetActiveKey) per listing or download.
+// getSession returns the session for drID, resolved on first access and cached
+// for the life of the process. Caching avoids two API calls (GetDataroom +
+// GetActiveKey) and an scrypt per listing or download.
 func (fs *webdavFS) getSession(ctx context.Context, drID string) (*service.DataroomSession, error) {
-	fs.sessMu.RLock()
-	if e, ok := fs.sessionCache[drID]; ok && time.Since(e.fetchedAt) < sessionCacheTTL {
-		sess := e.sess
-		fs.sessMu.RUnlock()
+	return fs.sessions.Get(ctx, drID, fs.resolveSession)
+}
 
-		return sess, nil
-	}
-	fs.sessMu.RUnlock()
-
-	sess, err := service.GetDataroomSession(ctx, fs.cfg, fs.client, drID, fs.passphraseReader)
-	if err != nil {
-		return nil, err
+// resolveSession performs the actual resolution (see sessionFn).
+func (fs *webdavFS) resolveSession(ctx context.Context, drID string) (*service.DataroomSession, error) {
+	if fs.sessionFn != nil {
+		return fs.sessionFn(ctx, drID)
 	}
 
-	fs.sessMu.Lock()
-	if fs.sessionCache == nil {
-		fs.sessionCache = make(map[string]*sessionCacheEntry)
-	}
-	fs.sessionCache[drID] = &sessionCacheEntry{sess: sess, fetchedAt: time.Now()}
-	fs.sessMu.Unlock()
-
-	return sess, nil
+	return service.GetDataroomSession(ctx, fs.cfg, fs.client, drID, fs.passphraseReader)
 }
 
 // listNodes returns the decrypted children of drID at nodePath, using a TTL cache.

--- a/cmd/webdav_test.go
+++ b/cmd/webdav_test.go
@@ -415,7 +415,7 @@ func newWebdavTestFS(srv *httptest.Server) *webdavFS {
 		Expiry:      time.Now().Add(time.Hour),
 	}), false, false)
 
-	return &webdavFS{
+	fs := &webdavFS{
 		client: client,
 		nodeCache: map[string]*nodeCacheEntry{
 			"retyc://dr1/": {
@@ -423,10 +423,10 @@ func newWebdavTestFS(srv *httptest.Server) *webdavFS {
 				fetchedAt: time.Now(),
 			},
 		},
-		sessionCache: map[string]*sessionCacheEntry{
-			"dr1": {sess: &service.DataroomSession{}, fetchedAt: time.Now()},
-		},
 	}
+	fs.sessions.Store("dr1", &service.DataroomSession{})
+
+	return fs
 }
 
 // newStaleReadHandle returns a handle built from the stale listing: its versionID
@@ -678,10 +678,7 @@ func TestWebdavFS_MutationsUseCachedSession(t *testing.T) {
 	fs.cache = newDataroomCache(func(_ context.Context) ([]dataroomCacheItem, error) {
 		return []dataroomCacheItem{{id: "dr1", title: "DR"}}, nil
 	})
-	fs.sessionCache["dr1"] = &sessionCacheEntry{
-		sess:      &service.DataroomSession{Identity: identity, PublicKey: pub},
-		fetchedAt: time.Now(),
-	}
+	fs.sessions.Store("dr1", &service.DataroomSession{Identity: identity, PublicKey: pub})
 	ctx := context.Background()
 
 	if err := fs.Mkdir(ctx, "/dataroom/DR/newdir", 0o755); err != nil {
@@ -830,4 +827,33 @@ func TestListNodes_WaiterHonoursContext(t *testing.T) {
 		t.Errorf("waiter error = %v, want context.Canceled", err)
 	}
 	close(gate)
+}
+
+// — Session cache wiring ——————————————————————————————————————————————————————
+
+// getSession must go through the process-lifetime session cache: the second
+// call for the same dataroom must not resolve again (see service.SessionCache).
+func TestWebdavFS_GetSession_ResolvedOnce(t *testing.T) {
+	var calls atomic.Int32
+	fs := &webdavFS{sessionFn: func(_ context.Context, drID string) (*service.DataroomSession, error) {
+		calls.Add(1)
+
+		return &service.DataroomSession{PublicKey: "pub-" + drID}, nil
+	}}
+	ctx := context.Background()
+
+	first, err := fs.getSession(ctx, "dr1")
+	if err != nil {
+		t.Fatalf("getSession: %v", err)
+	}
+	second, err := fs.getSession(ctx, "dr1")
+	if err != nil {
+		t.Fatalf("getSession (cached): %v", err)
+	}
+	if first != second {
+		t.Error("second getSession returned a different session: cache miss")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("sessionFn ran %d times, want 1", got)
+	}
 }

--- a/doc/mcp.md
+++ b/doc/mcp.md
@@ -55,6 +55,12 @@ Add the following to your client's MCP config file:
 | `RETYC_TOKEN`          | No       | Offline refresh token. If set, bypasses local token storage (useful in isolated environments). |
 | `RETYC_CONFIG_DIR`     | No       | Override config directory (default: `.retyc/` in dev mode, `~/.config/retyc/` in prod).        |
 
+Unlocking the private key with the passphrase runs an scrypt that needs ~256 MiB of
+working memory. The server resolves each dataroom session once and keeps it in memory for
+its whole lifetime, so that cost is paid on the first dataroom operation only (the memory
+is handed back to the OS right after). Transfer tools still unlock the key on every call
+unless the Linux keyring caches it.
+
 ## Authentication in MCP mode
 
 The MCP server operates in two modes:

--- a/doc/webdav.md
+++ b/doc/webdav.md
@@ -92,8 +92,11 @@ Notes and limitations:
   duplicate.
 - **File names containing `/`** cannot be represented as a single path component and are
   skipped from listings (a warning is printed to stderr).
-- Listings and dataroom sessions are cached briefly (30 s / 30 min respectively);
-  mutations made through the server invalidate the relevant cache immediately, but
+- Listings are cached briefly (30 s); dataroom sessions (the decrypted session
+  keypair) are resolved once per dataroom and kept for the life of the process, since
+  a dataroom's keypair never changes and each resolution unlocks the user key with an
+  scrypt costing ~256 MiB of working memory when no keyring caches it.
+  Mutations made through the server invalidate the relevant cache immediately, but
   changes made elsewhere (web app, another client) may take up to a minute to appear.
   A read that fails because the cached listing pointed at a deleted node drops that
   listing straight away, so the following request sees the current state (`404`)

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -44,6 +45,11 @@ func ResolveUserIdentity(cfg *config.Config, userKey *api.UserKey, reader Passph
 		if err != nil {
 			return nil, fmt.Errorf("wrong key passphrase: %w", err)
 		}
+		// The scrypt above needs ~256 MiB of working memory (age work factor 2^18).
+		// Hand it back to the OS now rather than letting the runtime scavenge it over
+		// minutes: long-running servers (webdav, mcp) would otherwise sit at a
+		// misleading RSS and trip container memory limits.
+		debug.FreeOSMemory()
 	}
 
 	identity, err := crypto.ParseIdentity(identityStr)

--- a/internal/service/dataroom.go
+++ b/internal/service/dataroom.go
@@ -96,9 +96,24 @@ type dataroomSession struct {
 	NameSalt   string
 }
 
-// resolveDataroomSession fetches the dataroom and the user's active key concurrently,
-// then decrypts the session key and per-dataroom name salt.
+// resolveDataroomSession returns the session for dataroomID, through the
+// process-wide SessionCache when EnableSessionCache was called, and by
+// resolving it directly otherwise.
 func resolveDataroomSession(
+	ctx context.Context, cfg *config.Config, client *api.Client, dataroomID string, reader PassphraseReader,
+) (*dataroomSession, error) {
+	if c := processSessions.Load(); c != nil {
+		return c.Get(ctx, dataroomID, func(ctx context.Context, drID string) (*DataroomSession, error) {
+			return resolveDataroomSessionUncached(ctx, cfg, client, drID, reader)
+		})
+	}
+
+	return resolveDataroomSessionUncached(ctx, cfg, client, dataroomID, reader)
+}
+
+// resolveDataroomSessionUncached fetches the dataroom and the user's active key
+// concurrently, then decrypts the session key and per-dataroom name salt.
+func resolveDataroomSessionUncached(
 	ctx context.Context, cfg *config.Config, client *api.Client, dataroomID string, reader PassphraseReader,
 ) (*dataroomSession, error) {
 	type drResult struct {
@@ -161,7 +176,8 @@ func resolveDataroomSession(
 }
 
 // DataroomSession is the exported alias for the per-dataroom crypto session.
-// Callers should cache it: resolving it requires two API calls and AGE crypto.
+// Callers should cache it (see SessionCache): resolving it requires two API
+// calls and AGE crypto.
 type DataroomSession = dataroomSession
 
 // GetDataroomSession resolves and returns the cryptographic session for a dataroom.

--- a/internal/service/session_cache.go
+++ b/internal/service/session_cache.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// SessionCache caches resolved dataroom sessions for the life of the process.
+// The zero value is ready to use.
+//
+// There is deliberately no TTL: a dataroom's session keypair never changes (a
+// rekey re-encrypts the same private key for a new member set, and a member who
+// lost access is refused by the API regardless), while every resolution costs two
+// API calls plus an scrypt to unlock the user key when no keyring caches it.
+//
+// Misses are single-flighted per dataroom and the resolutions themselves are
+// serialized across datarooms, so at most one scrypt (~256 MiB of working
+// memory) runs at any time.
+type SessionCache struct {
+	mu       sync.Mutex
+	sessions map[string]*DataroomSession
+	inflight map[string]*sessionFetch
+	// resolveMu serializes the actual resolutions across datarooms.
+	resolveMu sync.Mutex
+}
+
+// sessionFetch is an in-flight resolution shared by every caller that misses the
+// cache for the same dataroom while it runs. sess/err are written once, before
+// done is closed.
+type sessionFetch struct {
+	done chan struct{}
+	sess *DataroomSession
+	err  error
+}
+
+// Get returns the session for drID, calling resolve on the first access and
+// caching a successful result forever. A failed resolution is not cached.
+func (c *SessionCache) Get(
+	ctx context.Context, drID string, resolve func(ctx context.Context, drID string) (*DataroomSession, error),
+) (*DataroomSession, error) {
+	c.mu.Lock()
+	if sess, ok := c.sessions[drID]; ok {
+		c.mu.Unlock()
+
+		return sess, nil
+	}
+	if f, ok := c.inflight[drID]; ok {
+		c.mu.Unlock()
+		select {
+		case <-f.done:
+			return f.sess, f.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	f := &sessionFetch{done: make(chan struct{})}
+	if c.inflight == nil {
+		c.inflight = make(map[string]*sessionFetch)
+	}
+	c.inflight[drID] = f
+	c.mu.Unlock()
+
+	c.resolveMu.Lock()
+	f.sess, f.err = resolve(ctx, drID)
+	c.resolveMu.Unlock()
+
+	c.mu.Lock()
+	delete(c.inflight, drID)
+	if f.err == nil {
+		c.put(drID, f.sess)
+	}
+	c.mu.Unlock()
+	close(f.done)
+
+	return f.sess, f.err
+}
+
+// put stores sess for drID; c.mu must be held.
+func (c *SessionCache) put(drID string, sess *DataroomSession) {
+	if c.sessions == nil {
+		c.sessions = make(map[string]*DataroomSession)
+	}
+	c.sessions[drID] = sess
+}
+
+// Store caches sess for drID, replacing any previous entry (pre-warming, tests).
+func (c *SessionCache) Store(drID string, sess *DataroomSession) {
+	c.mu.Lock()
+	c.put(drID, sess)
+	c.mu.Unlock()
+}
+
+// processSessions is the process-wide cache consulted by resolveDataroomSession
+// once EnableSessionCache has been called. nil for one-shot CLI commands, which
+// resolve a session at most once per invocation anyway.
+var processSessions atomic.Pointer[SessionCache]
+
+// EnableSessionCache makes every service function that resolves a dataroom
+// session share one process-wide SessionCache. Long-running servers (mcp serve)
+// call it at startup; one-shot commands never do.
+func EnableSessionCache() {
+	processSessions.CompareAndSwap(nil, &SessionCache{})
+}
+
+// disableSessionCacheForTest drops the process-wide cache (tests only).
+func disableSessionCacheForTest() {
+	processSessions.Store(nil)
+}

--- a/internal/service/session_cache_test.go
+++ b/internal/service/session_cache_test.go
@@ -1,0 +1,218 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/retyc/retyc-cli/internal/api"
+	"github.com/retyc/retyc-cli/internal/config"
+	"github.com/retyc/retyc-cli/internal/crypto"
+)
+
+// countingResolver returns a resolver that records how many times it ran and the
+// maximum number of concurrent runs, blocking each run until release is closed.
+func countingResolver(release <-chan struct{}) (
+	fn func(context.Context, string) (*DataroomSession, error), calls, maxConcurrent *atomic.Int32,
+) {
+	calls, maxConcurrent = new(atomic.Int32), new(atomic.Int32)
+	var running atomic.Int32
+	fn = func(_ context.Context, drID string) (*DataroomSession, error) {
+		calls.Add(1)
+		if n := running.Add(1); n > maxConcurrent.Load() {
+			maxConcurrent.Store(n)
+		}
+		<-release
+		running.Add(-1)
+
+		return &DataroomSession{PublicKey: "pub-" + drID}, nil
+	}
+
+	return fn, calls, maxConcurrent
+}
+
+// The dataroom session keypair never changes (a rekey re-encrypts the same key
+// for a new member set), so once resolved it must never be resolved again: each
+// resolution costs an scrypt (~256 MiB of working memory) when no keyring helps.
+func TestSessionCache_ResolvedOnce(t *testing.T) {
+	release := make(chan struct{})
+	close(release)
+	resolve, calls, _ := countingResolver(release)
+	var c SessionCache
+	ctx := context.Background()
+
+	first, err := c.Get(ctx, "dr1", resolve)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	second, err := c.Get(ctx, "dr1", resolve)
+	if err != nil {
+		t.Fatalf("Get (cached): %v", err)
+	}
+	if first != second {
+		t.Error("second Get returned a different session: cache miss")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("resolver ran %d times, want 1", got)
+	}
+}
+
+// A failed resolution is not cached: the next caller retries.
+func TestSessionCache_ErrorNotCached(t *testing.T) {
+	var c SessionCache
+	boom := errors.New("boom")
+	n := 0
+	resolve := func(_ context.Context, _ string) (*DataroomSession, error) {
+		n++
+		if n == 1 {
+			return nil, boom
+		}
+
+		return &DataroomSession{PublicKey: "ok"}, nil
+	}
+	if _, err := c.Get(context.Background(), "dr1", resolve); !errors.Is(err, boom) {
+		t.Fatalf("first Get error = %v, want boom", err)
+	}
+	sess, err := c.Get(context.Background(), "dr1", resolve)
+	if err != nil || sess.PublicKey != "ok" {
+		t.Fatalf("second Get = %v, %v; want retry success", sess, err)
+	}
+}
+
+// Concurrent misses must not stack scrypts: callers for the same dataroom share
+// one resolution, and resolutions for different datarooms run one at a time.
+func TestSessionCache_SingleFlightAndSerialized(t *testing.T) {
+	release := make(chan struct{})
+	resolve, calls, maxConcurrent := countingResolver(release)
+	var c SessionCache
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	for _, drID := range []string{"dr1", "dr1", "dr1", "dr2", "dr2"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sess, err := c.Get(ctx, drID, resolve)
+			if err != nil {
+				t.Errorf("Get(%s): %v", drID, err)
+			} else if sess.PublicKey != "pub-"+drID {
+				t.Errorf("Get(%s) = %q", drID, sess.PublicKey)
+			}
+		}()
+	}
+	// Let every goroutine reach the cache miss before releasing the resolver.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	if got := calls.Load(); got != 2 {
+		t.Errorf("resolver ran %d times, want 2 (one per dataroom)", got)
+	}
+	if got := maxConcurrent.Load(); got != 1 {
+		t.Errorf("max concurrent resolutions = %d, want 1", got)
+	}
+}
+
+// A caller waiting on someone else's in-flight resolution must honour its context.
+func TestSessionCache_WaiterHonoursContext(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
+	resolve, _, _ := countingResolver(release)
+	var c SessionCache
+
+	go func() { _, _ = c.Get(context.Background(), "dr1", resolve) }()
+	time.Sleep(20 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := c.Get(ctx, "dr1", resolve); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Get error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+// Once the process-wide cache is enabled (mcp serve), every service function that
+// resolves a dataroom session goes through it: the second GetDataroomSession for
+// the same dataroom must hit neither the API nor the passphrase reader.
+func TestGetDataroomSession_UsesProcessCacheWhenEnabled(t *testing.T) {
+	t.Cleanup(disableSessionCacheForTest)
+
+	userKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	userPrivEnc, err := crypto.EncryptWithPassphrase([]byte(userKey.String()), "pw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessPrivEnc, err := crypto.EncryptStringForKeys(sessKey.String(), []string{userKey.Recipient().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var apiCalls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls.Add(1)
+		switch r.URL.Path {
+		case "/dataroom/dr1":
+			_ = json.NewEncoder(w).Encode(api.Dataroom{
+				ID: "dr1", SessionPublicKey: sessKey.Recipient().String(), SessionPrivateKeyEnc: sessPrivEnc,
+			})
+		case "/user/me/key/active":
+			_ = json.NewEncoder(w).Encode(api.UserKey{
+				ID: "k1", PublicKey: userKey.Recipient().String(), PrivateKeyEnc: userPrivEnc,
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := &config.Config{}
+	client := api.New(srv.URL, "retyc-test/1.0", oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: "t", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour),
+	}), false, false)
+	reads := 0
+	reader := func() (string, error) {
+		reads++
+
+		return "pw", nil
+	}
+	ctx := context.Background()
+
+	EnableSessionCache()
+
+	first, err := GetDataroomSession(ctx, cfg, client, "dr1", reader)
+	if err != nil {
+		t.Fatalf("GetDataroomSession: %v", err)
+	}
+	if first.PublicKey != sessKey.Recipient().String() {
+		t.Errorf("PublicKey = %q, want the session public key", first.PublicKey)
+	}
+	callsAfterFirst := apiCalls.Load()
+
+	second, err := GetDataroomSession(ctx, cfg, client, "dr1", reader)
+	if err != nil {
+		t.Fatalf("GetDataroomSession (cached): %v", err)
+	}
+	if second != first {
+		t.Error("second GetDataroomSession did not return the cached session")
+	}
+	if got := apiCalls.Load(); got != callsAfterFirst {
+		t.Errorf("API calls after second resolution = %d, want %d (no new call)", got, callsAfterFirst)
+	}
+	if reads != 1 {
+		t.Errorf("passphrase reader ran %d times, want 1", reads)
+	}
+}


### PR DESCRIPTION
Every dataroom session resolution unlocks the user key with an scrypt (age work factor 2^18, ~256 MiB of working memory) whenever no keyring caches the identity: containers, macOS, Windows. The WebDAV server re-ran it every 30 minutes per dataroom (session cache TTL) and the MCP server on every tool call (no cache at all), so long-running processes showed RSS peaks of several hundred MB and tripped container limits.

- Add service.SessionCache: one session per dataroom kept for the life of the process (a dataroom keypair never changes; a rekey re-encrypts the same key), single-flight per dataroom, resolutions serialized so at most one scrypt runs at a time, failures not cached.
- webdav serve holds its own instance in place of the TTL cache.
- mcp serve enables the process-wide cache consulted by every service function that resolves a dataroom session.
- ResolveUserIdentity returns the scrypt working memory to the OS right after decryption (RSS drops from ~530 MB to ~7 MB immediately instead of over several minutes).