### PR TITLE
:zap: Unlock the user key once at webdav serve startup

### DIFF
--- a/cmd/webdav.go
+++ b/cmd/webdav.go
@@ -22,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"filippo.io/age"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/webdav"
 	"golang.org/x/oauth2"
@@ -585,6 +586,10 @@ type webdavFS struct {
 	client           *api.Client
 	cache            *dataroomCache
 	passphraseReader service.PassphraseReader
+	// identity is the user's AGE identity unlocked once at startup; when set,
+	// sessions are resolved from it without fetching the user key or running
+	// scrypt again. nil falls back to passphraseReader (tests).
+	identity *age.HybridIdentity
 	// listFn performs the actual listing; nil means fetchNodes (tests inject a fake).
 	listFn func(ctx context.Context, drID, nodePath string) ([]service.DataroomNodeInfo, error)
 	// sessionFn resolves a dataroom session; nil means service.GetDataroomSession
@@ -593,7 +598,7 @@ type webdavFS struct {
 
 	nodeMu       sync.Mutex
 	nodeCache    map[string]*nodeCacheEntry
-	nodeGen      map[string]uint64    // bumped by every invalidation of that URI
+	nodeGen      map[string]uint64     // bumped by every invalidation of that URI
 	nodeInflight map[string]*nodeFetch // listings currently running, by URI
 
 	// sessions holds one resolved session per dataroom for the life of the
@@ -632,6 +637,9 @@ func (fs *webdavFS) getSession(ctx context.Context, drID string) (*service.Datar
 func (fs *webdavFS) resolveSession(ctx context.Context, drID string) (*service.DataroomSession, error) {
 	if fs.sessionFn != nil {
 		return fs.sessionFn(ctx, drID)
+	}
+	if fs.identity != nil {
+		return service.GetDataroomSessionWithIdentity(ctx, fs.client, drID, fs.identity)
 	}
 
 	return service.GetDataroomSession(ctx, fs.cfg, fs.client, drID, fs.passphraseReader)
@@ -1198,6 +1206,25 @@ var webdavCmd = &cobra.Command{
 	Short: "WebDAV server integration",
 }
 
+// webdavStartupCheck runs the validation calls performed before the server
+// binds its port: a dataroom listing (auth + API reachability) and the key
+// unlock, which bypasses the keyring so a wrong RETYC_KEY_PASSPHRASE fails at
+// startup rather than at the first dataroom access. The unlocked identity is
+// returned so the server never runs scrypt again.
+func webdavStartupCheck(
+	ctx context.Context, client *api.Client, reader service.PassphraseReader,
+) (*age.HybridIdentity, error) {
+	if _, err := service.ListDatarooms(ctx, client); err != nil {
+		return nil, fmt.Errorf("API connectivity check failed: %w", err)
+	}
+	identity, err := service.UnlockUserIdentity(ctx, client, reader)
+	if err != nil {
+		return nil, fmt.Errorf("key passphrase check failed: %w", err)
+	}
+
+	return identity, nil
+}
+
 var webdavServeCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Start a local WebDAV server exposing your datarooms",
@@ -1232,9 +1259,12 @@ Example:
 		}
 		client := api.New(cfg.API.BaseURL, cliUserAgent(), tokSrc, insecure, debug)
 
-		// Validation call — confirms auth + API reachability before binding the port.
-		if _, err := service.ListDatarooms(cmd.Context(), client); err != nil {
-			return fmt.Errorf("API connectivity check failed: %w", err)
+		// Fail-fast before binding the port: auth + API reachability, then the
+		// key passphrase itself (a wrong one would otherwise only surface on the
+		// first dataroom access). The unlocked identity is kept for the whole run.
+		identity, err := webdavStartupCheck(cmd.Context(), client, webdavPassphraseReader)
+		if err != nil {
+			return err
 		}
 
 		addr, _ := cmd.Flags().GetString("addr")
@@ -1256,6 +1286,7 @@ Example:
 				return items, nil
 			}),
 			passphraseReader: webdavPassphraseReader,
+			identity:         identity,
 		}
 
 		handler := &webdav.Handler{

--- a/cmd/webdav_test.go
+++ b/cmd/webdav_test.go
@@ -857,3 +857,113 @@ func TestWebdavFS_GetSession_ResolvedOnce(t *testing.T) {
 		t.Errorf("sessionFn ran %d times, want 1", got)
 	}
 }
+
+// — Startup checks ————————————————————————————————————————————————————————————
+
+// newStartupTestServer serves the two endpoints hit at webdav serve startup:
+// the dataroom listing (connectivity check) and the user's active key, whose
+// private half is encrypted under keyPassphrase.
+func newStartupTestServer(t *testing.T, keyPassphrase string) *httptest.Server {
+	t.Helper()
+	userKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	userPrivEnc, err := crypto.EncryptWithPassphrase([]byte(userKey.String()), keyPassphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dataroom/":
+			_, _ = io.WriteString(w, `{"items":[],"total":0}`)
+		case "/user/me/key/active":
+			_, _ = fmt.Fprintf(w, `{"id":"k1","public_key":%q,"private_key_enc":%q}`,
+				userKey.Recipient().String(), userPrivEnc)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func newStartupTestClient(srv *httptest.Server) *api.Client {
+	return api.New(srv.URL, "retyc-test/1.0",
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test", TokenType: "Bearer"}), false, false)
+}
+
+func TestWebdavStartupCheck_OK(t *testing.T) {
+	srv := newStartupTestServer(t, "good-pw")
+
+	identity, err := webdavStartupCheck(context.Background(), newStartupTestClient(srv), func() (string, error) {
+		return "good-pw", nil
+	})
+	if err != nil {
+		t.Fatalf("webdavStartupCheck() error = %v, want nil", err)
+	}
+	if identity == nil {
+		t.Fatal("webdavStartupCheck() returned a nil identity")
+	}
+}
+
+func TestWebdavStartupCheck_WrongPassphrase(t *testing.T) {
+	srv := newStartupTestServer(t, "good-pw")
+
+	_, err := webdavStartupCheck(context.Background(), newStartupTestClient(srv), func() (string, error) {
+		return "bad-pw", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "wrong key passphrase") {
+		t.Fatalf("webdavStartupCheck() error = %v, want wrong key passphrase", err)
+	}
+}
+
+func TestWebdavStartupCheck_APIUnreachable(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
+
+	_, err := webdavStartupCheck(context.Background(), newStartupTestClient(srv), func() (string, error) {
+		return "good-pw", nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "API connectivity check failed") {
+		t.Fatalf("webdavStartupCheck() error = %v, want connectivity failure", err)
+	}
+}
+
+// Once the identity has been unlocked at startup, resolving a dataroom session
+// must reuse it: no second fetch of the user key, no second scrypt.
+func TestWebdavFS_ResolveSession_ReusesStartupIdentity(t *testing.T) {
+	userKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessPrivEnc, err := crypto.EncryptStringForKeys(sessKey.String(), []string{userKey.Recipient().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/dataroom/dr1" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+
+			return
+		}
+		_, _ = fmt.Fprintf(w, `{"id":"dr1","session_public_key":%q,"session_private_key_enc":%q}`,
+			sessKey.Recipient().String(), sessPrivEnc)
+	}))
+	t.Cleanup(srv.Close)
+
+	fs := &webdavFS{client: newStartupTestClient(srv), identity: userKey}
+	sess, err := fs.getSession(context.Background(), "dr1")
+	if err != nil {
+		t.Fatalf("getSession: %v", err)
+	}
+	if sess.PublicKey != sessKey.Recipient().String() {
+		t.Errorf("PublicKey = %q, want %q", sess.PublicKey, sessKey.Recipient().String())
+	}
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -66,6 +66,41 @@ func ResolveUserIdentity(cfg *config.Config, userKey *api.UserKey, reader Passph
 	return identity, nil
 }
 
+// UnlockUserIdentity fetches the user's active key and decrypts it with the
+// passphrase returned by reader. Unlike ResolveUserIdentity it deliberately
+// bypasses the keyring cache: long-running servers (webdav) must fail fast at
+// startup on a wrong passphrase, not hours later when the cached identity
+// expires. The returned identity can then be reused for the life of the process
+// (see GetDataroomSessionWithIdentity), so the scrypt runs exactly once.
+func UnlockUserIdentity(ctx context.Context, client *api.Client, reader PassphraseReader) (
+	*age.HybridIdentity, error,
+) {
+	userKey, err := client.GetActiveKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("fetching user key: %w", err)
+	}
+	if userKey == nil {
+		return nil, fmt.Errorf("no active encryption key - set up your key in the web interface first")
+	}
+	passphrase, err := reader()
+	if err != nil {
+		return nil, err
+	}
+	identityStr, err := crypto.DecryptToStringWithPassphrase(userKey.PrivateKeyEnc, passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("wrong key passphrase: %w", err)
+	}
+	// Same reasoning as ResolveUserIdentity: release the ~256 MiB scrypt buffer now.
+	debug.FreeOSMemory()
+
+	identity, err := crypto.ParseIdentity(identityStr)
+	if err != nil {
+		return nil, fmt.Errorf("parsing AGE identity: %w", err)
+	}
+
+	return identity, nil
+}
+
 // — Auth flow (device flow + logout) ——————————————————————————————————————————
 
 // oidcCache caches FetchOIDCConfig results to avoid 2 round-trips per LoginPoll call.

--- a/internal/service/auth_test.go
+++ b/internal/service/auth_test.go
@@ -3,12 +3,17 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
+	"filippo.io/age"
+	"github.com/retyc/retyc-cli/internal/api"
 	"github.com/retyc/retyc-cli/internal/config"
+	"github.com/retyc/retyc-cli/internal/crypto"
 	"golang.org/x/oauth2"
 )
 
@@ -277,5 +282,80 @@ func TestLogout_RevocationWarning(t *testing.T) {
 	// Local token must still be deleted despite the warning.
 	if _, lerr := config.LoadToken(); lerr == nil {
 		t.Error("token should have been deleted even when revocation failed")
+	}
+}
+
+// — UnlockUserIdentity ———————————————————————————————————————————————————————
+
+// keyPassphraseTestServer serves /user/me/key/active with a private key
+// encrypted under the given passphrase, and returns the matching keypair.
+func keyPassphraseTestServer(t *testing.T, passphrase string) (*httptest.Server, *age.HybridIdentity) {
+	t.Helper()
+	userKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	userPrivEnc, err := crypto.EncryptWithPassphrase([]byte(userKey.String()), passphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/user/me/key/active" {
+			http.NotFound(w, r)
+
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.UserKey{
+			ID: "k1", PublicKey: userKey.Recipient().String(), PrivateKeyEnc: userPrivEnc,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv, userKey
+}
+
+func newKeyTestClient(srv *httptest.Server) *api.Client {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test", TokenType: "Bearer"})
+
+	return api.New(srv.URL, "retyc-test/1.0", ts, false, false)
+}
+
+func TestUnlockUserIdentity_Correct(t *testing.T) {
+	srv, userKey := keyPassphraseTestServer(t, "good-pw")
+
+	identity, err := UnlockUserIdentity(context.Background(), newKeyTestClient(srv), func() (string, error) {
+		return "good-pw", nil
+	})
+	if err != nil {
+		t.Fatalf("UnlockUserIdentity() error = %v, want nil", err)
+	}
+	if got, want := identity.Recipient().String(), userKey.Recipient().String(); got != want {
+		t.Errorf("identity recipient = %q, want %q", got, want)
+	}
+}
+
+func TestUnlockUserIdentity_Wrong(t *testing.T) {
+	srv, _ := keyPassphraseTestServer(t, "good-pw")
+
+	_, err := UnlockUserIdentity(context.Background(), newKeyTestClient(srv), func() (string, error) {
+		return "bad-pw", nil
+	})
+	if err == nil {
+		t.Fatal("UnlockUserIdentity() error = nil, want wrong passphrase error")
+	}
+	if !strings.Contains(err.Error(), "wrong key passphrase") {
+		t.Errorf("error = %q, want it to mention 'wrong key passphrase'", err)
+	}
+}
+
+func TestUnlockUserIdentity_ReaderError(t *testing.T) {
+	srv, _ := keyPassphraseTestServer(t, "good-pw")
+
+	want := errors.New("no passphrase")
+	_, err := UnlockUserIdentity(context.Background(), newKeyTestClient(srv), func() (string, error) {
+		return "", want
+	})
+	if !errors.Is(err, want) {
+		t.Errorf("error = %v, want %v", err, want)
 	}
 }

--- a/internal/service/dataroom.go
+++ b/internal/service/dataroom.go
@@ -149,7 +149,13 @@ func resolveDataroomSessionUncached(
 		return nil, err
 	}
 
-	sessionPrivKey, err := crypto.DecryptToString(dr.v.SessionPrivateKeyEnc, userIdentity)
+	return buildDataroomSession(dr.v, userIdentity)
+}
+
+// buildDataroomSession decrypts the dataroom's session key and per-dataroom
+// name salt with an already unlocked user identity.
+func buildDataroomSession(dr *api.Dataroom, userIdentity *age.HybridIdentity) (*dataroomSession, error) {
+	sessionPrivKey, err := crypto.DecryptToString(dr.SessionPrivateKeyEnc, userIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("decrypting dataroom session key: %w", err)
 	}
@@ -160,8 +166,8 @@ func resolveDataroomSessionUncached(
 	}
 
 	var nameSalt string
-	if dr.v.NodeNameSaltEnc != nil {
-		nameSalt, err = crypto.DecryptToString(*dr.v.NodeNameSaltEnc, sessionIdentity)
+	if dr.NodeNameSaltEnc != nil {
+		nameSalt, err = crypto.DecryptToString(*dr.NodeNameSaltEnc, sessionIdentity)
 		if err != nil {
 			return nil, fmt.Errorf("decrypting name salt: %w", err)
 		}
@@ -169,7 +175,7 @@ func resolveDataroomSessionUncached(
 
 	return &dataroomSession{
 		Identity:   sessionIdentity,
-		PublicKey:  dr.v.SessionPublicKey,
+		PublicKey:  dr.SessionPublicKey,
 		PrivateKey: sessionPrivKey,
 		NameSalt:   nameSalt,
 	}, nil
@@ -185,6 +191,20 @@ func GetDataroomSession(
 	ctx context.Context, cfg *config.Config, client *api.Client, dataroomID string, reader PassphraseReader,
 ) (*DataroomSession, error) {
 	return resolveDataroomSession(ctx, cfg, client, dataroomID, reader)
+}
+
+// GetDataroomSessionWithIdentity resolves the cryptographic session for a
+// dataroom using an already unlocked user identity (see UnlockUserIdentity):
+// one API call, no user-key fetch, no passphrase, no scrypt.
+func GetDataroomSessionWithIdentity(
+	ctx context.Context, client *api.Client, dataroomID string, userIdentity *age.HybridIdentity,
+) (*DataroomSession, error) {
+	dr, err := client.GetDataroom(ctx, dataroomID)
+	if err != nil {
+		return nil, fmt.Errorf("fetching dataroom: %w", err)
+	}
+
+	return buildDataroomSession(dr, userIdentity)
 }
 
 // fetchNodeItems lists the raw API node items at nodePath, supporting glob patterns.

--- a/internal/service/dataroom_test.go
+++ b/internal/service/dataroom_test.go
@@ -1,14 +1,19 @@
 package service
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/retyc/retyc-cli/internal/api"
 	"github.com/retyc/retyc-cli/internal/crypto"
+	"golang.org/x/oauth2"
 )
 
 // — ParseRetycURI —————————————————————————————————————————————————————————————
@@ -233,5 +238,59 @@ func TestNodesFromItems_ModTime(t *testing.T) {
 	}
 	if !nodes[1].ModTime().IsZero() {
 		t.Errorf("dir ModTime() = %v, want zero (API exposes no timestamp for folders)", nodes[1].ModTime())
+	}
+}
+
+// — GetDataroomSessionWithIdentity ———————————————————————————————————————————
+
+// A caller that already holds the unlocked user identity (webdav serve unlocks
+// it once at startup) must get a session without fetching the user key again:
+// only /dataroom/{id} may be hit.
+func TestGetDataroomSessionWithIdentity_SkipsUserKey(t *testing.T) {
+	userKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessKey, err := crypto.GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessPrivEnc, err := crypto.EncryptStringForKeys(sessKey.String(), []string{userKey.Recipient().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	saltEnc, err := crypto.EncryptStringForKeys("salt-123", []string{sessKey.Recipient().String()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/dataroom/dr1" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+
+			return
+		}
+		_ = json.NewEncoder(w).Encode(api.Dataroom{
+			ID: "dr1", SessionPublicKey: sessKey.Recipient().String(),
+			SessionPrivateKeyEnc: sessPrivEnc, NodeNameSaltEnc: &saltEnc,
+		})
+	}))
+	t.Cleanup(srv.Close)
+	client := api.New(srv.URL, "retyc-test/1.0",
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test", TokenType: "Bearer"}), false, false)
+
+	sess, err := GetDataroomSessionWithIdentity(context.Background(), client, "dr1", userKey)
+	if err != nil {
+		t.Fatalf("GetDataroomSessionWithIdentity() error = %v", err)
+	}
+	if sess.PublicKey != sessKey.Recipient().String() {
+		t.Errorf("PublicKey = %q, want %q", sess.PublicKey, sessKey.Recipient().String())
+	}
+	if sess.PrivateKey != sessKey.String() {
+		t.Error("PrivateKey does not match the dataroom session key")
+	}
+	if sess.NameSalt != "salt-123" {
+		t.Errorf("NameSalt = %q, want salt-123", sess.NameSalt)
 	}
 }


### PR DESCRIPTION
webdav serve only checked that RETYC_KEY_PASSPHRASE was set: a wrong value let the server start and browse, then failed on the first dataroom access. The server now unlocks the user key before binding its port and exits 1 on a wrong passphrase. The check bypasses the keyring on purpose, so a cached identity cannot mask a wrong passphrase until its TTL expires.

The unlocked identity is kept for the life of the process: dataroom sessions are resolved from it with a single GET (no user-key fetch, no scrypt), instead of re-running scrypt per dataroom when no keyring caches the identity (macOS, Windows, containers).