### PR TITLE
:wrench: Add OCI image labels to the Docker image

### DIFF
--- a/.github/workflows/_docker.yml
+++ b/.github/workflows/_docker.yml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # OCI `created` is the image build date; computed here rather than taken
+      # from the event payload, which lacks head_commit for some pushes (e.g.
+      # annotated tags) and would leave the label empty.
+      - name: Image build date
+        id: meta
+        run: echo "created=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
@@ -48,3 +55,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ inputs.tags }}
           build-args: VERSION=${{ inputs.version }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,19 @@ COPY --from=builder /etc/group /etc/group
 COPY --from=builder --chown=1000:1000 /home/retyc /home/retyc
 COPY --from=builder /retyc /retyc
 
+# OCI image annotations. `source` links the GHCR package to this repository
+# (it shows up under the repo's Packages and inherits its access settings).
+# Dynamic ones (revision, created) are injected by the workflow.
+ARG VERSION=dev
+LABEL org.opencontainers.image.title="retyc-cli" \
+      org.opencontainers.image.description="Official command-line interface and MCP server for Retyc: send transfers and manage datarooms from your terminal." \
+      org.opencontainers.image.source="https://github.com/retyc/retyc-cli" \
+      org.opencontainers.image.url="https://retyc.com" \
+      org.opencontainers.image.documentation="https://github.com/retyc/retyc-cli#readme" \
+      org.opencontainers.image.vendor="Retyc" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${VERSION}"
+
 USER 1000:1000
 ENV HOME=/home/retyc \
     XDG_CONFIG_HOME=/home/retyc/.config \


### PR DESCRIPTION
The image carried no org.opencontainers.image.* annotations. In particular the missing `source` label leaves the GHCR package unlinked from the repository.